### PR TITLE
Temp fix for views infinite scroll, switch to ajax pager

### DIFF
--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -27,7 +27,6 @@ dependencies:
     - options
     - taxonomy
     - user
-    - views_infinite_scroll
 id: events
 label: 'Calendar Page'
 module: views
@@ -1187,27 +1186,9 @@ display:
           separator: ', '
           field_api_classes: false
       pager:
-        type: infinite_scroll
+        type: none
         options:
           offset: 0
-          items_per_page: 10
-          total_pages: null
-          id: 0
-          tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          views_infinite_scroll:
-            button_text: 'Load More'
-            automatically_load_content: false
-            initially_load_all_pages: false
       exposed_form:
         type: bef
         options:
@@ -1620,7 +1601,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1716,7 +1696,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1735,6 +1714,27 @@ display:
     display_plugin: block
     position: 1
     display_options:
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       exposed_form:
         type: bef
         options:
@@ -1803,6 +1803,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         type_1:
           id: type_1
           table: node_field_data
@@ -2079,6 +2080,7 @@ display:
           1: AND
       defaults:
         use_ajax: false
+        pager: false
         exposed_form: false
         filters: false
         filter_groups: false
@@ -2131,7 +2133,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -2150,6 +2151,27 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       filters:
         status:
           id: status
@@ -2164,6 +2186,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         type_1:
           id: type_1
           table: node_field_data
@@ -2439,6 +2462,7 @@ display:
         groups:
           1: AND
       defaults:
+        pager: false
         filters: false
         filter_groups: false
       display_description: ''
@@ -2469,6 +2493,27 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       filters:
         status:
           id: status
@@ -2483,6 +2528,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         type_1:
           id: type_1
           table: node_field_data
@@ -2758,6 +2804,7 @@ display:
         groups:
           1: AND
       defaults:
+        pager: false
         filters: false
         filter_groups: false
       display_description: ''
@@ -2788,6 +2835,27 @@ display:
     display_plugin: block
     position: 1
     display_options:
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       exposed_form:
         type: bef
         options:
@@ -2856,6 +2924,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         type_1:
           id: type_1
           table: node_field_data
@@ -3132,6 +3201,7 @@ display:
           1: AND
       defaults:
         use_ajax: false
+        pager: false
         exposed_form: false
         filters: false
         filter_groups: false

--- a/config/sync/views.view.newsroom.yml
+++ b/config/sync/views.view.newsroom.yml
@@ -15,7 +15,6 @@ dependencies:
     - node
     - options
     - user
-    - views_infinite_scroll
 id: newsroom
 label: Newsroom
 module: views
@@ -397,15 +396,17 @@ display:
           separator: ', '
           field_api_classes: false
       pager:
-        type: infinite_scroll
+        type: full
         options:
           offset: null
           items_per_page: 5
-          total_pages: 5
+          total_pages: null
           id: 0
           tags:
             next: 'Next ›'
             previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -414,10 +415,7 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          views_infinite_scroll:
-            button_text: 'See more news'
-            automatically_load_content: false
-            initially_load_all_pages: false
+          quantity: 9
       exposed_form:
         type: basic
         options:
@@ -636,6 +634,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         type:
           id: type
           table: node_field_data
@@ -716,6 +715,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          accept_null: false
         field_category_value:
           id: field_category_value
           table: node__field_category

--- a/config/sync/views.view.senator_microsite_content.yml
+++ b/config/sync/views.view.senator_microsite_content.yml
@@ -36,7 +36,6 @@ dependencies:
     - options
     - taxonomy
     - user
-    - views_infinite_scroll
 id: senator_microsite_content
 label: 'Microsite Content'
 module: views
@@ -642,7 +641,7 @@ display:
           separator: ', '
           field_api_classes: false
       pager:
-        type: infinite_scroll
+        type: full
         options:
           offset: 0
           items_per_page: 4
@@ -651,6 +650,8 @@ display:
           tags:
             next: 'Next ›'
             previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -659,10 +660,7 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          views_infinite_scroll:
-            button_text: 'Load More'
-            automatically_load_content: false
-            initially_load_all_pages: false
+          quantity: 9
       exposed_form:
         type: bef
         options:
@@ -3541,7 +3539,7 @@ display:
           separator: ', '
           field_api_classes: false
       pager:
-        type: infinite_scroll
+        type: full
         options:
           offset: 0
           items_per_page: 5
@@ -3550,6 +3548,8 @@ display:
           tags:
             next: 'Next ›'
             previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -3558,10 +3558,7 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          views_infinite_scroll:
-            button_text: 'See more news'
-            automatically_load_content: false
-            initially_load_all_pages: false
+          quantity: 9
       exposed_form:
         type: bef
         options:

--- a/web/themes/custom/nysenate_theme/src/templates/views/views-view-unformatted--microsite-newsroom-content.html.twig
+++ b/web/themes/custom/nysenate_theme/src/templates/views/views-view-unformatted--microsite-newsroom-content.html.twig
@@ -29,15 +29,4 @@
       </div>
     {% endfor %}
   </div>
-
-  {% if contents|length > 5 %}
-    <div class="item-list">
-      <div class="pager pager-load-more">
-        <span class="pager-next first last">
-          <a class="load-more">See More
-            {{ panel.pagination_link_text }}</a>
-        </span>
-      </div>
-    </div>
-  {% endif %}
 </div>

--- a/web/themes/custom/nysenate_theme/src/templates/views/views-view-unformatted--newsroom--press-releases.html.twig
+++ b/web/themes/custom/nysenate_theme/src/templates/views/views-view-unformatted--newsroom--press-releases.html.twig
@@ -29,13 +29,4 @@
       </div>
     {% endfor %}
   </div>
-  {% if contents|length > 5 %}
-    <div class="item-list">
-      <div class="pager pager-load-more">
-        <span class="pager-next first last">
-          <a class="load-more">See More News
-            {{ panel.pagination_link_text }}</a>
-        </span>
-      </div>
-    </div>
-  {% endif %}
+

--- a/web/themes/custom/nysenate_theme/src/templates/views/views-view-unformatted--senator-microsite-content--article-footer.html.twig
+++ b/web/themes/custom/nysenate_theme/src/templates/views/views-view-unformatted--senator-microsite-content--article-footer.html.twig
@@ -32,16 +32,3 @@
     </div>
   {% endfor %}
 </div>
-
-{% set limit = 4 %}
-
-{% if contents|length > limit %}
-  <div class="item-list" data-limit="{{ limit }}">
-    <div class="pager pager-load-more">
-      <span class="pager-next first last">
-        <a class="load-more">See More News
-          {{ panel.pagination_link_text }}</a>
-      </span>
-    </div>
-  </div>
-{% endif %}


### PR DESCRIPTION
- Switches sitewide/senator newsroom/footer news views to use ajax pager
- Changes calendar day view to show all, and week/month to use ajax pager 
- Removes hard coded infinite scroll code from relevant templates