### PR TITLE
Reroute email settings prod config file

### DIFF
--- a/web/profiles/custom/nysenate/config/prod/reroute_email.settings.yml
+++ b/web/profiles/custom/nysenate/config/prod/reroute_email.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: gbxsfZiC2MMjzyiqbCPrKXXxlhQDa0pMNs0FSt_33ds
+enable: false
+roles: {  }
+allowed: ''
+description: true
+message: true
+mailkeys: ''
+mailkeys_skip: ''


### PR DESCRIPTION
Forgot to put reroute email settings in prod folder after deleting from global config :-|