### PR TITLE
STEP 1 Rain Admin Removal: Remove feature only modules

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -173,35 +173,9 @@ module:
   queue_ui: 0
   queue_unique: 0
   rabbit_hole: 0
-  rain_accordion: 0
-  rain_accordion_item: 0
   rain_admin_module: 0
-  rain_block_card: 0
-  rain_block_quote: 0
-  rain_blocks: 0
-  rain_breaker: 0
-  rain_card: 0
-  rain_card_list: 0
-  rain_content: 0
   rain_core: 0
-  rain_embed: 0
-  rain_form: 0
-  rain_gallery: 0
-  rain_gallery_carousel: 0
-  rain_gallery_item: 0
-  rain_hero: 0
-  rain_landing: 0
-  rain_map: 0
-  rain_media: 0
   rain_media_bundle: 0
-  rain_paragraphs: 0
-  rain_quote: 0
-  rain_quote_carousel: 0
-  rain_slider: 0
-  rain_slider_item: 0
-  rain_styles: 0
-  rain_text: 0
-  rain_views: 0
   rdf: 0
   recaptcha: 0
   redirect: 0


### PR DESCRIPTION
uninstalls these Rain feature modules (there are a couple more to go, but this is start):

- rain_views
- rain_text
- rain_slider
- rain_slider_item
- rain_quote_carousel
- rain_quote
- rain_map
- rain_hero
- rain_gallery_carousel
- rain_gallery_item
- rain_gallery
- rain_media
- rain_form
- rain_embed
- rain_card_list
- rain_card
- rain_breaker
- rain_block_quote
- rain_block_card
- rain_accordion
- rain_accordion_item
- rain_paragraphs
- rain_styles
- rain_blocks