### PR TITLE
Hotfix: adding an additional Pantheon quicksilver hook

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -22,3 +22,8 @@ workflows:
       - type: webphp
         description: "Invoke the processes after code has been pushed."
         script: private/hooks/afterSync.php
+  create_cloud_development_environment:
+    after:
+      - type: webphp
+        description: 'Invoke the process after a MultiDev has been created.'
+        script: private/hooks/afterCloudCreate.php

--- a/web/private/hooks/afterCloudCreate.php
+++ b/web/private/hooks/afterCloudCreate.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * A pantheon quicksilver script to run when a multidev is created.
+ *
+ * See https://docs.pantheon.io/guides/quicksilver.
+ */
+
+$drushCommands = [
+  'deploy' => [
+    '--yes',
+  ],
+];
+
+// Iterate over each drush command and execute it on the system.
+foreach ($drushCommands as $subCommand => $args) {
+  $command = "drush {$subCommand} " . implode(' ', $args);
+  echo sprintf('Running %s...', $command);
+  passthru($command);
+}
+
+echo 'All drush commands have been executed!';
+
+exit(0);


### PR DESCRIPTION
https://docs.pantheon.io/guides/quicksilver/hooks#hooks

We needed the `create_cloud_development_environment` to be added to Pantheon.yml so the first time after a multidev env is created, it will import config. We may also need one for database syncs.