### PR TITLE
Aten NYS 52: Fix pagination issue on newsroom views

### DIFF
--- a/config/sync/views.view.newsroom.yml
+++ b/config/sync/views.view.newsroom.yml
@@ -15,6 +15,7 @@ dependencies:
     - node
     - options
     - user
+    - views_infinite_scroll
 id: newsroom
 label: Newsroom
 module: views
@@ -396,7 +397,7 @@ display:
           separator: ', '
           field_api_classes: false
       pager:
-        type: full
+        type: infinite_scroll
         options:
           offset: null
           items_per_page: 5
@@ -405,8 +406,6 @@ display:
           tags:
             next: 'Next ›'
             previous: '‹ Previous'
-            first: '« First'
-            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -415,7 +414,10 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          quantity: 9
+          views_infinite_scroll:
+            button_text: 'Load More'
+            automatically_load_content: false
+            initially_load_all_pages: false
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.senator_microsite_content.yml
+++ b/config/sync/views.view.senator_microsite_content.yml
@@ -36,6 +36,7 @@ dependencies:
     - options
     - taxonomy
     - user
+    - views_infinite_scroll
 id: senator_microsite_content
 label: 'Microsite Content'
 module: views
@@ -3539,7 +3540,7 @@ display:
           separator: ', '
           field_api_classes: false
       pager:
-        type: full
+        type: infinite_scroll
         options:
           offset: 0
           items_per_page: 5
@@ -3548,8 +3549,6 @@ display:
           tags:
             next: 'Next ›'
             previous: '‹ Previous'
-            first: '« First'
-            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -3558,7 +3557,10 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          quantity: 9
+          views_infinite_scroll:
+            button_text: 'Load More'
+            automatically_load_content: false
+            initially_load_all_pages: false
       exposed_form:
         type: bef
         options:

--- a/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-tabs/nysenate-tabs.js
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-tabs/nysenate-tabs.js
@@ -16,7 +16,9 @@
         }
 
         tabInput.each(function () {
-          if ($(this).is(':checked')) {
+          // Use .attr('checked') instead of .is(:checked), because
+          // tabInput.on('click') logic below operates on checked attribute.
+          if ($(this).attr('checked')) {
             $(this).parent().addClass('active');
           }
         });


### PR DESCRIPTION
1. Fixes pagination issue on newsroom views (by switching to infinite scroll, as recommended by Alison)
2. Fixes secondary bug on the main newsroom where tabbing between "All news" and "Press Releases" then using pagination would break the tabs