### PR TITLE
Aten NYS-57: Advanced legislation search issues

### DIFF
--- a/config/sync/views.view.advanced_legislation_search.yml
+++ b/config/sync/views.view.advanced_legislation_search.yml
@@ -2350,6 +2350,19 @@ display:
     display_options:
       title: 'Advanced Legislation Search - Resolutions'
       sorts:
+        field_ol_session:
+          id: field_ol_session
+          table: search_api_index_core_search
+          field: field_ol_session
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
         field_ol_print_no:
           id: field_ol_print_no
           table: search_api_index_core_search

--- a/web/modules/custom/nys_legislation_explorer/src/Form/SearchAdvancedLegislationForm.php
+++ b/web/modules/custom/nys_legislation_explorer/src/Form/SearchAdvancedLegislationForm.php
@@ -206,11 +206,16 @@ class SearchAdvancedLegislationForm extends FormBase {
       $dates['publish_date'] = $args['publish_date'] ?? NULL;
       $dates['meeting_date'] = $args['meeting_date'] ?? NULL;
       foreach ($dates as $date) {
-        if ($date !== NULL) {
-          $parts = explode("-", $date);
-          $month_default = $parts[1];
-          $year_default = substr($date, 0, 4);
+        if ($date == NULL) {
+          continue;
         }
+        $year_default = substr($date, 0, 4);
+        $parts = explode("-", $date);
+        // Don't set month filter if date range is full year.
+        if ($parts[1] == '1' && $parts[5] == '12') {
+          continue;
+        }
+        $month_default = $parts[1];
       }
     }
     // Set type default to transcript subtype, otherwise fall back on base type.

--- a/web/modules/custom/nys_legislation_explorer/src/Form/SearchAdvancedLegislationForm.php
+++ b/web/modules/custom/nys_legislation_explorer/src/Form/SearchAdvancedLegislationForm.php
@@ -481,8 +481,6 @@ class SearchAdvancedLegislationForm extends FormBase {
           'sponsor' => $values['sponsor'] ?: '',
           'full_text' => $values['full_text'] ?: '',
           'committee' => $values['committee'] ?: '',
-          'sort_by' => 'field_ol_last_status_date',
-          'sort_order' => 'DESC',
         ];
         break;
 
@@ -501,8 +499,6 @@ class SearchAdvancedLegislationForm extends FormBase {
           'type' => $values['type'] ?: '',
           'meeting_date' => $date_range ?: '',
           'committee' => $values['committee'] ?: '',
-          'sort_by' => ' field_date_range',
-          'sort_order' => 'DESC',
         ];
         break;
 
@@ -510,8 +506,6 @@ class SearchAdvancedLegislationForm extends FormBase {
         $params = [
           'type' => $values['type'] ?: '',
           'date' => $date_range ?: '',
-          'sort_by' => 'field_date_range',
-          'sort_order' => 'DESC',
         ];
         break;
 
@@ -522,8 +516,6 @@ class SearchAdvancedLegislationForm extends FormBase {
           'transcript_type' => $values['type'] ?: '',
           'publish_date' => $date_range ?: '',
           'full_text' => $values['full_text'] ?: '',
-          'sort_by' => 'field_ol_publish_date',
-          'sort_order' => 'DESC',
         ];
         break;
 

--- a/web/modules/custom/nys_legislation_explorer/src/Form/SearchAdvancedLegislationForm.php
+++ b/web/modules/custom/nys_legislation_explorer/src/Form/SearchAdvancedLegislationForm.php
@@ -213,6 +213,11 @@ class SearchAdvancedLegislationForm extends FormBase {
         }
       }
     }
+    // Set type default to transcript subtype, otherwise fall back on base type.
+    $type_default = $args['transcript_type'] ?? '';
+    if (empty($type_default)) {
+      $type_default = $args['type'] ?? '';
+    }
 
     $form['advanced_search']['advanced_search_text'] = [
       '#type' => 'item',
@@ -230,7 +235,7 @@ class SearchAdvancedLegislationForm extends FormBase {
         'floor' => t('Session Transcripts'),
         'public_hearing' => t('Public Hearing Transcripts'),
       ],
-      '#default_value' => $args['type'] ?? NULL,
+      '#default_value' => $type_default,
       '#attributes' => [
         'class' => ['content-type'],
       ],

--- a/web/modules/custom/nys_legislation_explorer/src/Form/SearchAdvancedLegislationForm.php
+++ b/web/modules/custom/nys_legislation_explorer/src/Form/SearchAdvancedLegislationForm.php
@@ -483,8 +483,6 @@ class SearchAdvancedLegislationForm extends FormBase {
           'printno' => $values['printno'] ?: '',
           'sponsor' => $values['sponsor'] ?: '',
           'full_text' => $values['full_text'] ?: '',
-          'sort_by' => 'field_ol_print_no',
-          'sort_order' => 'DESC',
         ];
         break;
 

--- a/web/themes/custom/nysenate_theme/src/patterns/components/pager/pager.twig
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/pager/pager.twig
@@ -20,15 +20,15 @@
       {# Now generate the actual pager piece. #}
       {% block pager_items %}
         {% for key, item in items.pages %}
-          <li class="pager__item{{ current == loop.index ? ' is-active' : '' }}">
-            {% if current == loop.index %}
+          <li class="pager__item{{ current == key ? ' is-active' : '' }}">
+            {% if current == key %}
               {% set title = 'Current page'|t %}
             {% else %}
               {% set title = 'Go to page @key'|t({'@key': key}) %}
             {% endif %}
             <a href="{{ item.href }}" title="{{ title }}" class="pager__control {{ item.attributes.class }}"{{ item.attributes|without('href', 'title', 'class') }}>
               <span class="visually-hidden">
-                {{ current == loop.index ? 'Current page'|t : 'Page'|t }}
+                {{ current == key ? 'Current page'|t : 'Page'|t }}
               </span>
               {{- key -}}
             </a>

--- a/web/themes/custom/nysenate_theme/src/templates/content/node--meeting--search-teaser.html.twig
+++ b/web/themes/custom/nysenate_theme/src/templates/content/node--meeting--search-teaser.html.twig
@@ -1,6 +1,6 @@
 {{ attach_library('nysenate_theme/nysenate-search-results-listing') }}
 
-{% set meeting_date = content.date|date('F j, Y') %}
+{% set meeting_date = node.field_date_range.value|date('F j, Y') %}
 
 {% include "@nysenate_theme/nysenate-search-results-listing/nysenate-search-results-listing.twig" with {
   "article": {


### PR DESCRIPTION
- Fixes bug when paginating beyond 5th results page
- Fixes advanced search bugs:
  1. Resolution sort order incorrect
  2. Transcript refine search not preserving search type
  3. Refine search form setting month to “January“ incorrectly
  4. Committee Meeting Agenda date defaulting to today’s date
  5. 2023 Public Hearing Transcript’s showing wrong date