### PR TITLE
NYS-64: MCP role should not have access to all committees

### DIFF
--- a/config/sync/core.entity_form_display.node.in_the_news.default.yml
+++ b/config/sync/core.entity_form_display.node.in_the_news.default.yml
@@ -212,14 +212,10 @@ content:
       revision: false
     third_party_settings: {  }
   field_committee:
-    type: entity_reference_autocomplete
+    type: options_select
     weight: 26
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_committee_featured:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.node.video.default.yml
+++ b/config/sync/core.entity_form_display.node.video.default.yml
@@ -49,14 +49,10 @@ content:
       display_label: true
     third_party_settings: {  }
   field_committee:
-    type: entity_reference_autocomplete
+    type: options_select
     weight: 7
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_date:
     type: datetime_default

--- a/web/modules/custom/nys_senators/nys_senators.module
+++ b/web/modules/custom/nys_senators/nys_senators.module
@@ -9,6 +9,7 @@ use Drupal\block_content\Entity\BlockContent;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultAllowed;
 use Drupal\Core\Database\Query\AlterableInterface;
+use Drupal\Core\Database\Query\Condition;
 use Drupal\Core\Database\Query\SelectInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Render\BubbleableMetadata;
@@ -16,6 +17,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
+use Drupal\nys_users\UsersHelper;
 use Drupal\pathauto\Entity\PathautoPattern;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\TermInterface;
@@ -1235,6 +1237,57 @@ function nys_senators_query_nys_senators_access_alter(AlterableInterface $query)
 
     }
   }
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ */
+function nys_senators_query_term_access_alter(AlterableInterface $query) {
+  // Prevent recursion with our entity query in nys_users/src/UsersHelper.php.
+  if ($query->hasTag('prevent_recursion')) {
+    return;
+  }
+
+  // Only alter the query when we routes we care about.
+  $route_match = \Drupal::routeMatch();
+  $routes = [
+    'node.add',
+    'entity.node.edit_form',
+  ];
+  if (!in_array($route_match->getRouteName(), $routes)) {
+    return;
+  }
+
+  $current_user = \Drupal::currentUser();
+  // If the user is not an MCP, return.
+  if (!UsersHelper::isMcp($current_user)) {
+    return;
+  }
+
+  $primary_table = '';
+  $tables = $query->getTables();
+  $target_tables = ['taxonomy_term_data', 'taxonomy_term_field_data'];
+  foreach ($tables as $info) {
+    $table = $info['table'];
+    if (!in_array($table, $target_tables)) {
+      continue;
+    }
+    $primary_table = $info['alias'];
+  }
+  // Get the senator management TIDs from the current user.
+  $senator_tids = UsersHelper::getUserSenatorManagement($current_user);
+  // Get the committee TIDs from the senator TIDs based on the committee chair.
+  $committee_tids = UsersHelper::getCommitteesBySenators($senator_tids);
+  if (empty($committee_tids)) {
+    return;
+  }
+
+  $vids = ['committees'];
+  $query->leftJoin('taxonomy_term_field_data', 'ttfd', $primary_table . '.tid = ttfd.tid');
+  $or = new Condition('OR');
+  $or->condition($primary_table . '.tid', array_values($committee_tids), 'IN');
+  $or->condition('ttfd.vid', $vids, 'NOT IN');
+  $query->condition($or);
 }
 
 /**

--- a/web/modules/custom/nys_senators/nys_senators.module
+++ b/web/modules/custom/nys_senators/nys_senators.module
@@ -1242,8 +1242,8 @@ function nys_senators_query_nys_senators_access_alter(AlterableInterface $query)
 /**
  * Implements hook_query_TAG_alter().
  */
-function nys_senators_query_term_access_alter(AlterableInterface $query) {
-  // Prevent recursion with our entity query in nys_users/src/UsersHelper.php.
+function nys_senators_query_taxonomy_term_access_alter(AlterableInterface $query): void {
+  // Prevent recursion with entity query in nys_senators/src/SenatorsHelper.php.
   if ($query->hasTag('prevent_recursion')) {
     return;
   }
@@ -1274,10 +1274,8 @@ function nys_senators_query_term_access_alter(AlterableInterface $query) {
     }
     $primary_table = $info['alias'];
   }
-  // Get the senator management TIDs from the current user.
-  $senator_tids = UsersHelper::getUserSenatorManagement($current_user);
-  // Get the committee TIDs from the senator TIDs based on the committee chair.
-  $committee_tids = UsersHelper::getCommitteesBySenators($senator_tids);
+
+  $committee_tids = UsersHelper::getManagedCommittees($current_user);
   if (empty($committee_tids)) {
     return;
   }

--- a/web/modules/custom/nys_senators/src/SenatorsHelper.php
+++ b/web/modules/custom/nys_senators/src/SenatorsHelper.php
@@ -385,4 +385,21 @@ class SenatorsHelper {
       );
   }
 
+  /**
+   * Gets a list of committees by senator tids found in field_chair.
+   *
+   * @param array $tids
+   *   Senator term IDs.
+   */
+  public static function getChairedCommittees(array $tids): array {
+    $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+    $query = $storage->getQuery()
+      ->condition('vid', 'committees')
+      ->condition('field_chair', $tids, 'IN')
+      ->addTag('prevent_recursion')
+      ->accessCheck(TRUE);
+
+    return $query->execute();
+  }
+
 }

--- a/web/modules/custom/nys_senators/src/SenatorsHelper.php
+++ b/web/modules/custom/nys_senators/src/SenatorsHelper.php
@@ -392,14 +392,20 @@ class SenatorsHelper {
    *   Senator term IDs.
    */
   public static function getChairedCommittees(array $tids): array {
-    $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
-    $query = $storage->getQuery()
-      ->condition('vid', 'committees')
-      ->condition('field_chair', $tids, 'IN')
-      ->addTag('prevent_recursion')
-      ->accessCheck(TRUE);
+    try {
+      $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+      $query = $storage->getQuery()
+        ->condition('vid', 'committees')
+        ->condition('field_chair', $tids, 'IN')
+        ->addTag('prevent_recursion')
+        ->accessCheck(TRUE);
 
-    return $query->execute();
+      return $query->execute();
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('nys_senators')->error($e->getMessage());
+      return [];
+    }
   }
 
 }

--- a/web/modules/custom/nys_users/src/UsersHelper.php
+++ b/web/modules/custom/nys_users/src/UsersHelper.php
@@ -178,14 +178,10 @@ class UsersHelper {
   public static function getManagedSenators(mixed $user): array {
     $user = static::resolveUser($user);
     $senator_tids = [];
+    $senators = $user->field_senator_multiref->getValue() ?? $senator_tids;
+    $senator_tids = array_column($senators, 'target_id', 'target_id');
 
-    // If the user doesn't have the field, or it's empty, return an empty array.
-    if (!$user->hasField('field_senator_multiref') || $user->field_senator_multiref->isEmpty()) {
-      return $senator_tids;
-    }
-    // Otherwise, return an array of senator term IDs.
-    $senators = $user->field_senator_multiref->getValue();
-    return array_column($senators, 'target_id', 'target_id');
+    return $senator_tids;
   }
 
   /**

--- a/web/modules/custom/nys_users/src/UsersHelper.php
+++ b/web/modules/custom/nys_users/src/UsersHelper.php
@@ -3,6 +3,7 @@
 namespace Drupal\nys_users;
 
 use Drupal\Core\Session\AccountInterface;
+use Drupal\nys_senators\SenatorsHelper;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\user\Entity\User;
 
@@ -174,7 +175,7 @@ class UsersHelper {
    * @param \Drupal\user\Entity\User|int|null $user
    *   Either a User entity or the ID of one.  If NULL, current user is used.
    */
-  public static function getUserSenatorManagement(mixed $user): array {
+  public static function getManagedSenators(mixed $user): array {
     $user = static::resolveUser($user);
     $senator_tids = [];
 
@@ -188,20 +189,16 @@ class UsersHelper {
   }
 
   /**
-   * Gets a list of committees by senator tids found in field_chair.
+   * Gets a list of all committees a user is assigned to for management.
    *
-   * @param array $tids
-   *   Senator term IDs.
+   * @param \Drupal\user\Entity\User|int|null $user
+   *   Either a User entity or the ID of one.  If NULL, current user is used.
    */
-  public static function getCommitteesBySenators(array $tids): array {
-    $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
-    $query = $storage->getQuery()
-      ->condition('vid', 'committees')
-      ->condition('field_chair', $tids, 'IN')
-      ->addTag('prevent_recursion')
-      ->accessCheck(TRUE);
-
-    return $query->execute();
+  public static function getManagedCommittees(mixed $user): array {
+    $user = static::resolveUser($user);
+    $senator_tids = UsersHelper::getManagedSenators($user);
+    // Get the committee TIDs from senator TIDs based on the committee chair.
+    return SenatorsHelper::getChairedCommittees($senator_tids);
   }
 
 }


### PR DESCRIPTION
This was created in response to https://atendesign.atlassian.net/browse/NYS-64

Per @routinet 's direction, I added a couple new methods to web/modules/custom/nys_users/src/UsersHelper.php

Totally open to naming convention there. Naming stuff is hard!!!

I ended up using a `hook_query_TAG_alter` because it will be a more flexible solution if we need to further limit access to taxonomy terms for MCP users, etc.