### PR TITLE
NYS-65: copies private settings file when creating a MD env

### DIFF
--- a/.github/workflows/pantheon-deploy-multidev.yml
+++ b/.github/workflows/pantheon-deploy-multidev.yml
@@ -99,6 +99,15 @@ jobs:
         if: ${{ !env.PANTHEON_MULTIDEV_EXISTS }}
         run: terminus env:create ${{ vars.PANTHEON_SITE }}.${{ vars.PANTHEON_MULTIDEV_CLONE_ENV }} $PANTHEON_MULTIDEV --no-files
 
+      - name: Copy private settings file to multidev environment
+        run: |
+          DEST_SFTP_COMMAND=$(terminus connection:info --field=sftp_command -- ${{ vars.PANTHEON_SITE }}.${{ env.PANTHEON_MULTIDEV }})
+          SOURCE_SFTP_COMMAND=$(terminus connection:info --field=sftp_command -- ${{ vars.PANTHEON_SITE }}.${{ vars.PANTHEON_MULTIDEV_CLONE_ENV }})
+          SETTINGS_FILE="files/private/private_settings.php"
+          LOCAL_FILE="${{ runner.temp }}/private_settings.php"
+          echo -e "get $SETTINGS_FILE $LOCAL_FILE\nbye" | $SOURCE_SFTP_COMMAND
+          echo -e "put $LOCAL_FILE $SETTINGS_FILE\nbye" | $DEST_SFTP_COMMAND
+
       - name: Post a comment to the PR
         if: success()
         uses: ouzi-dev/commit-status-updater@v2


### PR DESCRIPTION
@routinet Quicksilver didn't give me enough cross-environment information to be able to accomplish this, but terminus does, so I'm trying it here in the GH Action. This would copy the file from `dev`.