### PR TITLE
bill: update opengraph tags

### DIFF
--- a/config/sync/metatag.metatag_defaults.node__bill.yml
+++ b/config/sync/metatag.metatag_defaults.node__bill.yml
@@ -9,3 +9,8 @@ tags:
   description: '[node:field_ol_summary]'
   title: 'NY State [node:field_ol_chamber] Bill [node:title]'
   image_src: '[site:url]sites/default/files/2023/04/12/ny_senate_bill_share2.png'
+  og_title: 'NY State [node:field_ol_chamber] Bill [node:title]'
+  og_description: '[node:field_ol_summary]'
+  og_site_name: '[site:name]'
+  twitter_cards_description: '[node:field_ol_summary]'
+  twitter_cards_title: 'NY State [node:field_ol_chamber] Bill [node:title]'


### PR DESCRIPTION
This updates the open graph and twitter tags for what is shown on a bill

For example the URL https://www.nysenate.gov/legislation/bills/2023/S2783 currently renders the following


```
<meta property="og:title" content="2023-S2783" />
<meta name="twitter:title" content="2023-S2783" />
```

But would change to


```
<meta property="og:title" content="NY State Senate Bill 2023-S2783" />
<meta property="og:description" content="Prohibits landlords, lessors, sub-lessors and grantors from demanding brokers&#039; fees from a tenant." />
<meta property="twitter:title" content="NY State Senate Bill 2023-S2783" />
<meta property="twitter:description" content="Prohibits landlords, lessors, sub-lessors and grantors from demanding brokers&#039; fees from a tenant." />
```

The current URL on `threads.net` renders as follows - If there are ideas on an appropriate image to use that would help too.

![Screenshot 2024-01-26 at 9 15 26 AM](https://github.com/nysenate/NYSenate.gov-Website-D9/assets/45028/a6b4849e-8fe3-492f-b4c2-0558caf1623c)
