### PR TITLE
Fix: prevent event listing page promo banner duplication 

### DIFF
--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -17,6 +17,7 @@ dependencies:
     - node.type.session
     - taxonomy.vocabulary.committees
     - taxonomy.vocabulary.senator
+    - views.view.global_promo_banner
   module:
     - address
     - better_exposed_filters
@@ -1593,7 +1594,18 @@ display:
       relationships: {  }
       use_ajax: true
       header: {  }
-      footer: {  }
+      footer:
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: view
+          empty: false
+          view_to_insert: 'global_promo_banner:global_promo_banner'
+          inherit_arguments: false
       display_extenders: {  }
     cache_metadata:
       max-age: -1

--- a/web/themes/custom/nysenate_theme/src/templates/views/views-view--events.html.twig
+++ b/web/themes/custom/nysenate_theme/src/templates/views/views-view--events.html.twig
@@ -117,11 +117,6 @@
   {% if more %}
     {{ more }}
   {% endif %}
-  {% if footer %}
-    <div class="view-footer">
-      {{ footer }}
-    </div>
-  {% endif %}
   {% if feed_icons %}
     <div class="feed-icons">
       {{ feed_icons }}
@@ -130,6 +125,9 @@
   {% if calendar_downloads %}
     {{ calendar_downloads }}
   {% endif %}
+  {% if footer %}
+    <div class="view-footer">
+      {{ footer }}
+    </div>
+  {% endif %}
 </div>
-
-{{ drupal_view('global_promo_banner', 'global_promo_banner') }}


### PR DESCRIPTION
By rendering promo banner through main view instead of template, avoiding Views AJAX issue.