### PR TITLE
Fix: resolve bug affecting all exposed filters on the month display of the event listing page

### DIFF
--- a/.github/workflows/pantheon-deploy-multidev.yml
+++ b/.github/workflows/pantheon-deploy-multidev.yml
@@ -106,7 +106,7 @@ jobs:
           SETTINGS_FILE="files/private/private_settings.php"
           LOCAL_FILE="${{ runner.temp }}/private_settings.php"
           echo -e "get $SETTINGS_FILE $LOCAL_FILE\nbye" | $SOURCE_SFTP_COMMAND
-          echo -e "put $LOCAL_FILE $SETTINGS_FILE\nbye" | $DEST_SFTP_COMMAND
+          echo -e "mkdir files/private\nput $LOCAL_FILE $SETTINGS_FILE\nbye" | $DEST_SFTP_COMMAND
 
       - name: Post a comment to the PR
         if: success()

--- a/web/themes/custom/nysenate_theme/src/patterns/components/event-calendar/event-calendar.js
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/event-calendar/event-calendar.js
@@ -36,10 +36,12 @@
         viewType = 'month';
         formatType = 'm/Y';
         submit = $('#views-exposed-form-events-page-2 input[type="submit"]');
+        $('.form-item-date.js-form-type-textfield').hide();
       }
       if ($('.view-events.view-display-id-page_3').length > 0) {
         viewType = 'week';
         submit = $('#views-exposed-form-events-page-3 input[type="submit"]');
+        $('.form-item-date-min.form-type-textfield').hide();
       }
 
       if ($('.form-item-date.js-form-type-textfield input').val()) {
@@ -52,7 +54,6 @@
             .split('/');
           const lastIndex = splitDate.length - 1;
 
-          $('.form-item-date.js-form-type-textfield input').val(`${splitDate[0]}/${splitDate[lastIndex]}`);
           $('#datepicker input').val(`${splitDate[0]}/${splitDate[lastIndex]}`);
         }
       }


### PR DESCRIPTION
By removing broken exposed filter date input manipulation Javascript. Additionally, hide duplicate/misleading date filter from week and month views.