### PR TITLE
Feature/aten nys 71  automated comment closing session year

### DIFF
--- a/config/sync/ultimate_cron.job.nys_comment_cron.yml
+++ b/config/sync/ultimate_cron.job.nys_comment_cron.yml
@@ -1,0 +1,30 @@
+uuid: c780e28f-b58d-444d-ba42-8bb364e9adb0
+langcode: en
+status: true
+dependencies:
+  module:
+    - nys_comment
+title: 'Default cron handler'
+id: nys_comment_cron
+weight: 0
+module: nys_comment
+callback: nys_comment_cron
+scheduler:
+  id: crontab
+  configuration:
+    rules:
+      - '0 0 1 * *'
+    catch_up: 0
+launcher:
+  id: serial
+  configuration:
+    timeouts:
+      lock_timeout: 3600
+    launcher:
+      thread: 0
+logger:
+  id: database
+  configuration:
+    method: '3'
+    expire: 1209600
+    retain: 1000

--- a/web/modules/custom/nys_comment/nys_comment.install
+++ b/web/modules/custom/nys_comment/nys_comment.install
@@ -18,3 +18,23 @@ function nys_comment_uninstall() {
   // Deleting field storage.
   FieldStorageConfig::loadByName('user', 'field_user_banned_comments')->delete();
 }
+
+/**
+ * Inserts missing comment field data required for Cron hook.
+ */
+function nys_comment_update_8001() {
+  $subquery = \Drupal::database()->select('node_field_data', 'n')
+    ->condition('n.type', ['bill', 'resolution'], 'IN')
+    ->condition('nc.entity_id', '', 'IS NULL');
+  $subquery->leftJoin('node__field_comments', 'nc', 'nc.entity_id=n.nid AND n.type=nc.bundle');
+  $subquery->addField('n', 'type', 'bundle');
+  $subquery->addExpression("'0'", 'deleted');
+  $subquery->addField('n', 'nid', 'entity_id');
+  $subquery->addField('n', 'vid', 'revision_id');
+  $subquery->addExpression("'en'", 'langcode');
+  $subquery->addExpression("'0'", 'delta');
+  $subquery->addExpression("'2'", 'field_comments_status');
+  \Drupal::database()->insert('node__field_comments')
+    ->from($subquery)
+    ->execute();
+}

--- a/web/modules/custom/nys_comment/nys_comment.module
+++ b/web/modules/custom/nys_comment/nys_comment.module
@@ -180,7 +180,7 @@ function nys_comment_deploy_default_rejected_value() {
  * Implements hook_cron().
  */
 function nys_comment_cron() {
-  $content_types = ['bill'];
+  $content_types = ['bill', 'resolution'];
   $current_session_year = \Drupal::config('nys_config.settings')->get('nys_session_year');
 
   // Get all nodes with open comments created outside current session.
@@ -189,22 +189,18 @@ function nys_comment_cron() {
   $query->join('node__field_comments', 'nc', 'n.nid = nc.entity_id');
   $query->fields('n', ['nid', 'type']);
   $query->fields('ns', ['field_ol_session_value']);
-  $query->condition('nc.field_comments_status', '1', '!=');
+  $query->condition('nc.field_comments_status', '2');
   $query->condition('n.type', $content_types, 'IN');
-  $query->condition('ns.field_ol_session_value', $current_session_year, '<=');
-  $results = $query->execute()->fetchAll();
+  $query->condition('ns.field_ol_session_value', $current_session_year, '<');
+  $result = $query->execute()->fetchAll();
 
-  // Close comments.
-  foreach ($results as $result) {
-    $nid = $result->nid;
-    $upd = Drupal::database()->update('node__field_comments');
-    $upd->fields(['field_comments_status' => 1]);
-    $upd->condition('entity_id', $nid);
-    $upd->execute();
-    Drupal::entityTypeManager()
-      ->getStorage('node')
-      ->resetCache([
-        $nid,
-      ]);
-  }
+  // Close comments and clear cache for relevant nodes.
+  $nids = array_column($result, 'nid');
+  $upd = Drupal::database()->update('node__field_comments');
+  $upd->fields(['field_comments_status' => 1]);
+  $upd->condition('entity_id', $nids, 'IN');
+  $upd->execute();
+  Drupal::entityTypeManager()
+    ->getStorage('node')
+    ->resetCache($nids);
 }

--- a/web/modules/custom/nys_comment/nys_comment.module
+++ b/web/modules/custom/nys_comment/nys_comment.module
@@ -183,24 +183,56 @@ function nys_comment_cron() {
   $content_types = ['bill', 'resolution'];
   $current_session_year = \Drupal::config('nys_config.settings')->get('nys_session_year');
 
+  // Set missing node__field_comments values (e.g. migrated resolutions).
+  $nodes_with_comment_field_row = Drupal::database()
+    ->select('node__field_comments', 'nc')
+    ->fields('nc', ['entity_id'])
+    ->execute()
+    ->fetchAll();
+  $nids_with_comment_field_row = array_column($nodes_with_comment_field_row, 'entity_id');
+  $nodes_missing_comment_field_row = Drupal::database()
+    ->select('node', 'n')
+    ->fields('n', ['nid', 'vid', 'type'])
+    ->condition('n.type', $content_types, 'IN')
+    ->condition('n.nid', $nids_with_comment_field_row, 'NOT IN')
+    ->execute()
+    ->fetchAll();
+  foreach ($nodes_missing_comment_field_row as $node_missing_comment_field) {
+    Drupal::database()
+      ->insert('node__field_comments')
+      ->fields([
+        'bundle' => $node_missing_comment_field->type,
+        'deleted' => 0,
+        'entity_id' => $node_missing_comment_field->nid,
+        'revision_id' => $node_missing_comment_field->vid,
+        'langcode' => 'en',
+        'delta' => 0,
+        'field_comments_status' => 2,
+      ])
+      ->execute();
+  }
+
   // Get all nodes with open comments created outside current session.
   $query = Drupal::database()->select('node', 'n');
   $query->join('node__field_ol_session', 'ns', 'n.nid = ns.entity_id');
   $query->join('node__field_comments', 'nc', 'n.nid = nc.entity_id');
-  $query->fields('n', ['nid', 'type']);
-  $query->fields('ns', ['field_ol_session_value']);
-  $query->condition('nc.field_comments_status', '2');
-  $query->condition('n.type', $content_types, 'IN');
-  $query->condition('ns.field_ol_session_value', $current_session_year, '<');
-  $result = $query->execute()->fetchAll();
+  $result = $query->fields('n', ['nid', 'type'])
+    ->fields('ns', ['field_ol_session_value'])
+    ->condition('nc.field_comments_status', '2')
+    ->condition('n.type', $content_types, 'IN')
+    ->condition('ns.field_ol_session_value', $current_session_year, '<')
+    ->execute()
+    ->fetchAll();
 
   // Close comments and clear cache for relevant nodes.
-  $nids = array_column($result, 'nid');
-  $upd = Drupal::database()->update('node__field_comments');
-  $upd->fields(['field_comments_status' => 1]);
-  $upd->condition('entity_id', $nids, 'IN');
-  $upd->execute();
-  Drupal::entityTypeManager()
-    ->getStorage('node')
-    ->resetCache($nids);
+  if (!empty($result)) {
+    $nids = array_column($result, 'nid');
+    Drupal::database()->update('node__field_comments')
+      ->fields(['field_comments_status' => 1])
+      ->condition('entity_id', $nids, 'IN')
+      ->execute();
+    Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->resetCache($nids);
+  }
 }

--- a/web/modules/custom/nys_comment/nys_comment.module
+++ b/web/modules/custom/nys_comment/nys_comment.module
@@ -207,23 +207,3 @@ function nys_comment_cron() {
       ->resetCache($nids);
   }
 }
-
-/**
- * Inserts missing comment field data required for Cron hook.
- */
-function nys_comment_update_8001() {
-  $subquery = \Drupal::database()->select('node_field_data', 'n')
-    ->condition('n.type', ['bill', 'resolution'], 'IN')
-    ->condition('nc.entity_id', '', 'IS NULL');
-  $subquery->leftJoin('node__field_comments', 'nc', 'nc.entity_id=n.nid AND n.type=nc.bundle');
-  $subquery->addField('n', 'type', 'bundle');
-  $subquery->addExpression("'0'", 'deleted');
-  $subquery->addField('n', 'nid', 'entity_id');
-  $subquery->addField('n', 'vid', 'revision_id');
-  $subquery->addExpression("'en'", 'langcode');
-  $subquery->addExpression("'0'", 'delta');
-  $subquery->addExpression("'2'", 'field_comments_status');
-  \Drupal::database()->insert('node__field_comments')
-    ->from($subquery)
-    ->execute();
-}

--- a/web/modules/custom/nys_comment/nys_comment.module
+++ b/web/modules/custom/nys_comment/nys_comment.module
@@ -178,32 +178,28 @@ function nys_comment_deploy_default_rejected_value() {
 
 /**
  * Implements hook_cron().
- *
- * @See: https://git.drupalcode.org/project/auto_close_comments/-/blob/c77a9d3918d378476f3d73f949f602ff8531c592/auto_close_comments.module
  */
 function nys_comment_cron() {
   $content_types = ['bill'];
   $current_session_year = \Drupal::config('nys_config.settings')->get('nys_session_year');
-  $current_session_start = strtotime('01/01/' . $current_session_year);
 
   // Get all nodes with open comments created outside current session.
   $query = Drupal::database()->select('node', 'n');
-  $query->join('node_field_data', 'nfd', 'n.nid = nfd.nid');
-  $query->join('node__comment', 'nc', 'n.nid = nc.entity_id');
+  $query->join('node__field_ol_session', 'ns', 'n.nid = ns.entity_id');
+  $query->join('node__field_comments', 'nc', 'n.nid = nc.entity_id');
   $query->fields('n', ['nid', 'type']);
-  $query->fields('nfd', ['created']);
-  $query->condition('nfd.status', '1', '=');
-  $query->condition('nc.comment_status', '1', '!=');
+  $query->fields('ns', ['field_ol_session_value']);
+  $query->condition('nc.field_comments_status', '1', '!=');
   $query->condition('n.type', $content_types, 'IN');
-  $query->condition('nfd.created', strtotime($current_session_start), '<=');
-  $z_results = $query->execute()->fetchAll();
+  $query->condition('ns.field_ol_session_value', $current_session_year, '<=');
+  $results = $query->execute()->fetchAll();
 
   // Close comments.
-  foreach ($z_results as $result) {
+  foreach ($results as $result) {
     $nid = $result->nid;
-    $upd = Drupal::database()->update('node__comment');
-    $upd->fields(['comment_status' => 1]);
-    $upd->condition('entity_id', $nid, '=');
+    $upd = Drupal::database()->update('node__field_comments');
+    $upd->fields(['field_comments_status' => 1]);
+    $upd->condition('entity_id', $nid);
     $upd->execute();
     Drupal::entityTypeManager()
       ->getStorage('node')

--- a/web/modules/custom/nys_comment/nys_comment.module
+++ b/web/modules/custom/nys_comment/nys_comment.module
@@ -175,3 +175,40 @@ function nys_comment_deploy_default_rejected_value() {
     $comment->save();
   }
 }
+
+/**
+ * Implements hook_cron().
+ *
+ * @See: https://git.drupalcode.org/project/auto_close_comments/-/blob/c77a9d3918d378476f3d73f949f602ff8531c592/auto_close_comments.module
+ */
+function nys_comment_cron() {
+  $content_types = ['bill'];
+  $current_session_year = \Drupal::config('nys_config.settings')->get('nys_session_year');
+  $current_session_start = strtotime('01/01/' . $current_session_year);
+
+  // Get all nodes with open comments created outside current session.
+  $query = Drupal::database()->select('node', 'n');
+  $query->join('node_field_data', 'nfd', 'n.nid = nfd.nid');
+  $query->join('node__comment', 'nc', 'n.nid = nc.entity_id');
+  $query->fields('n', ['nid', 'type']);
+  $query->fields('nfd', ['created']);
+  $query->condition('nfd.status', '1', '=');
+  $query->condition('nc.comment_status', '1', '!=');
+  $query->condition('n.type', $content_types, 'IN');
+  $query->condition('nfd.created', strtotime($current_session_start), '<=');
+  $z_results = $query->execute()->fetchAll();
+
+  // Close comments.
+  foreach ($z_results as $result) {
+    $nid = $result->nid;
+    $upd = Drupal::database()->update('node__comment');
+    $upd->fields(['comment_status' => 1]);
+    $upd->condition('entity_id', $nid, '=');
+    $upd->execute();
+    Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->resetCache([
+        $nid,
+      ]);
+  }
+}

--- a/web/modules/custom/nys_comment/nys_comment.module
+++ b/web/modules/custom/nys_comment/nys_comment.module
@@ -183,35 +183,6 @@ function nys_comment_cron() {
   $content_types = ['bill', 'resolution'];
   $current_session_year = \Drupal::config('nys_config.settings')->get('nys_session_year');
 
-  // Set missing node__field_comments values (e.g. migrated resolutions).
-  $nodes_with_comment_field_row = Drupal::database()
-    ->select('node__field_comments', 'nc')
-    ->fields('nc', ['entity_id'])
-    ->execute()
-    ->fetchAll();
-  $nids_with_comment_field_row = array_column($nodes_with_comment_field_row, 'entity_id');
-  $nodes_missing_comment_field_row = Drupal::database()
-    ->select('node', 'n')
-    ->fields('n', ['nid', 'vid', 'type'])
-    ->condition('n.type', $content_types, 'IN')
-    ->condition('n.nid', $nids_with_comment_field_row, 'NOT IN')
-    ->execute()
-    ->fetchAll();
-  foreach ($nodes_missing_comment_field_row as $node_missing_comment_field) {
-    Drupal::database()
-      ->insert('node__field_comments')
-      ->fields([
-        'bundle' => $node_missing_comment_field->type,
-        'deleted' => 0,
-        'entity_id' => $node_missing_comment_field->nid,
-        'revision_id' => $node_missing_comment_field->vid,
-        'langcode' => 'en',
-        'delta' => 0,
-        'field_comments_status' => 2,
-      ])
-      ->execute();
-  }
-
   // Get all nodes with open comments created outside current session.
   $query = Drupal::database()->select('node', 'n');
   $query->join('node__field_ol_session', 'ns', 'n.nid = ns.entity_id');
@@ -235,4 +206,24 @@ function nys_comment_cron() {
       ->getStorage('node')
       ->resetCache($nids);
   }
+}
+
+/**
+ * Inserts missing comment field data required for Cron hook.
+ */
+function nys_comment_update_8001() {
+  $subquery = \Drupal::database()->select('node_field_data', 'n')
+    ->condition('n.type', ['bill', 'resolution'], 'IN')
+    ->condition('nc.entity_id', '', 'IS NULL');
+  $subquery->leftJoin('node__field_comments', 'nc', 'nc.entity_id=n.nid AND n.type=nc.bundle');
+  $subquery->addField('n', 'type', 'bundle');
+  $subquery->addExpression("'0'", 'deleted');
+  $subquery->addField('n', 'nid', 'entity_id');
+  $subquery->addField('n', 'vid', 'revision_id');
+  $subquery->addExpression("'en'", 'langcode');
+  $subquery->addExpression("'0'", 'delta');
+  $subquery->addExpression("'2'", 'field_comments_status');
+  \Drupal::database()->insert('node__field_comments')
+    ->from($subquery)
+    ->execute();
 }


### PR DESCRIPTION
Dev note: implemented cron hook in nys_comment module instead of nys_bills module with an eye towards similar comment automation in other content types. Open to feedback if this doesn't match business rules.