### PR TITLE
Bug fixes resolved during NYS-79 development

### DIFF
--- a/config/sync/config_split.config_split.local.yml
+++ b/config/sync/config_split.config_split.local.yml
@@ -12,7 +12,6 @@ storage: folder
 folder: profiles/custom/nysenate/config/local
 module:
   devel: 0
-  migrate_devel: 0
   stage_file_proxy: 0
   twig_vardumper: 0
 theme: {  }

--- a/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.js
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.js
@@ -140,10 +140,7 @@
 
         origActionBar = $('.c-actionbar').first();
         actionBar = origActionBar.clone();
-
-        if (!self.isInSession()) {
-          actionBar.appendTo(nav).addClass('hidden');
-        }
+        actionBar.appendTo(nav).addClass('hidden');
 
         menu = nav.find('.c-nav--wrap');
         headerBar = nav.find('.c-header-bar');
@@ -290,9 +287,6 @@
         ) {
           actionBar.removeClass('hidden');
           origActionBar.addClass('hidden');
-          if (this.isInSession()) {
-            origNav.css('visibility', 'visible');
-          }
         }
         else if (
           this.isMovingUp(currentTop, previousTop) &&
@@ -301,9 +295,6 @@
           if (toggleActionBar !== 'show-actionbar') {
             actionBar.addClass('hidden');
             origActionBar.removeClass('hidden');
-          }
-          if (this.isInSession()) {
-            origNav.css('visibility', 'hidden');
           }
         }
       }


### PR DESCRIPTION
This PR addresses 2 potential bugs:

1. Remove orphaned migrate_devel from local config split
2. Disables homepage in-session behavior for actionbar, due to JS glitches when minimizing / expanding on scroll

I carved this out as a separate PR from my main NYS-79 branch, in case there's a good reason for either item above to be this way.

For item 2 above, note that this means the homepage "in session" actionbar follows the user on scroll (like it does for typical interior pages). If we want the actionbar to collapse in this context, we'll want to fix the JS code that handles this, as right now the code is causing misfiring expanding / collapsing actionbar animations, in addition to the header "ghosting" effected noted in NYS-68.