### PR TITLE
Feature/Aten NYS 79: remove senator header JS dependency

### DIFF
--- a/web/themes/custom/nysenate_theme/nysenate_theme.theme
+++ b/web/themes/custom/nysenate_theme/nysenate_theme.theme
@@ -333,6 +333,7 @@ function nysenate_theme_preprocess_block_content__microsite_hero(&$variables) {
 
   $node = \Drupal::routeMatch()->getParameter('node');
 
+  $variables['is_senator_landing'] = FALSE;
   if (!empty($node) && $node->hasField('field_microsite_page_type') && !$node->get('field_microsite_page_type')->isEmpty()) {
     $term = $node->field_microsite_page_type->entity ?? [];
     if ($term instanceof TermInterface) {

--- a/web/themes/custom/nysenate_theme/src/patterns/components/hero/hero.twig
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/hero/hero.twig
@@ -2,20 +2,24 @@
 {{ attach_library('rain_theme/media') }}
 {% import '@nysenate_theme/icons/_icons-macro.twig' as icons %}
 
-<section class="hero {% if type == "senator" %} hero--senator{% if is_senator_landing is same as(false) %} hero--senator-collapsed{% endif %}{% else %} hero--homepage{% endif %} {% if type == " default" %} hero--default{% endif %} {% if type == " press_conference" or type == " public_hearing" or type == " session" %}hero--public-hearing{% endif %}">
+<section class="hero {% if type == "senator" %} hero--senator{% if not is_senator_landing %} hero--senator-collapsed{% endif %}{% else %} hero--homepage{% endif %} {% if type == " default" %} hero--default{% endif %} {% if type == " press_conference" or type == " public_hearing" or type == " session" %}hero--public-hearing{% endif %}">
   {% if type == "senator" %}
     {# start of senator hero #}
     <div class="l-header-region l-row l-row--hero c-senator-hero">
       <div class="c-senator-hero--img" id="senatorImage">
-        {% if image_hero %}
+        {% if not is_senator_landing %}
+          {{ senator_headshot }}
+        {% elseif image_hero %}
           {{ image_hero }}
         {% else %}
           <img src="{{ default_image }}">
         {% endif %}
       </div>
-      <div id="smallShotImage">
-        {{ senator_headshot }}
-      </div>
+      {% if is_senator_landing %}
+        <div id="smallShotImage">
+          {{ senator_headshot }}
+        </div>
+      {% endif %}
       <div class="c-senator-hero--info {% if not is_active %} inactive-pallette {% endif %}">
         <div>
           <h2 class="c-senator-hero--title">

--- a/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.js
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.js
@@ -45,12 +45,9 @@
 
       if (self.isSenatorLanding(origNav)) {
         actionBar = nav.find('.c-senator-hero');
+        nav.find('#senatorImage').html(nav.find('#smallShotImage').html());
 
         if (self.isSenatorCollapsed()) {
-          $(document).ready(function () {
-            $('#senatorImage').html($('#smallShotImage').html());
-          });
-
           // place origin Nav
           origNav
             .prependTo('.page')
@@ -364,7 +361,6 @@
           currentTop < origNav.outerHeight() &&
           !this.isSenatorCollapsed()
         ) {
-          $('#senatorImage').html($('#smallShotImage').html());
           actionBar.addClass('hidden');
           headerBar.removeClass('collapsed');
         }
@@ -392,7 +388,6 @@
           }
         }
         else if (currentTop >= heroHeight) {
-          $('#senatorImage').html($('#smallShotImage').html());
           actionBar.removeClass('hidden');
           headerBar.addClass('collapsed');
           this.checkMenuState(menu, currentTop, previousTop);
@@ -438,21 +433,15 @@
       if (!topBarToggle) {
         if (
           currentTop > nav.outerHeight() &&
-          !headerBar.hasClass('collapsed') &&
-          !nav.hasClass('l-header__collapsed')
+          !headerBar.hasClass('collapsed')
         ) {
           headerBar.addClass('collapsed');
-          nav.addClass('l-header__collapsed');
         }
         else if (
           currentTop <= nav.outerHeight() &&
-          headerBar.hasClass('collapsed') &&
-          nav.hasClass('l-header__collapsed')
+          headerBar.hasClass('collapsed')
         ) {
           headerBar.removeClass('collapsed');
-          if (!this.isSenatorCollapsed()) {
-            nav.removeClass('l-header__collapsed');
-          }
         }
       }
     },

--- a/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.js
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.js
@@ -3,9 +3,9 @@
   Drupal.behaviors.nysenateHeader = {
     attach: function (context) {
       // If admin toolbar is present, abort and use static nav bar.
-      //if ($('#toolbar-administration').length > 0) {
-      //  return;
-      //}
+      if ($('#toolbar-administration').length > 0) {
+       return;
+      }
 
       let self = this;
       let userScroll = 0;

--- a/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.js
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.js
@@ -432,14 +432,12 @@
 
       if (!topBarToggle) {
         if (
-          currentTop > nav.outerHeight() &&
-          !headerBar.hasClass('collapsed')
+          currentTop > nav.outerHeight()
         ) {
           headerBar.addClass('collapsed');
         }
         else if (
-          currentTop <= nav.outerHeight() &&
-          headerBar.hasClass('collapsed')
+          currentTop <= nav.outerHeight()
         ) {
           headerBar.removeClass('collapsed');
         }

--- a/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.scss
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.scss
@@ -868,13 +868,6 @@ ul.c-login--list {
   }
 }
 
-.hero--senator-collapsed {
-
-  #js-sticky {
-    visibility: hidden;
-  }
-}
-
 .c-header--btn {
   display: block;
   float: left;

--- a/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.twig
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.twig
@@ -4,7 +4,7 @@
 {% set error_page = false or is_error_page %}
 
 <header
-  id="js-sticky" role="banner" class="l-header {{ error_page ? 'error-page-header' : '' }}" style="z-index: 100;">
+  id="js-sticky" role="banner" class="l-header {{ error_page ? 'error-page-header' : '' }} {% if not is_senator_landing %} l-header__collapsed{% endif %}" style="z-index: 100;">
   <!-- Begin Header -->
   <div class="panel-pane pane-block pane-nys-blocks-sitewide-header-bar-block">
 

--- a/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.twig
+++ b/web/themes/custom/nysenate_theme/src/patterns/components/nysenate-header/nysenate-header.twig
@@ -4,7 +4,7 @@
 {% set error_page = false or is_error_page %}
 
 <header
-  id="js-sticky" role="banner" class="l-header {{ error_page ? 'error-page-header' : '' }} {% if not is_senator_landing %} l-header__collapsed{% endif %}" style="z-index: 100;">
+  id="js-sticky" role="banner" class="l-header{{ error_page ? ' error-page-header' : '' }}{{ not is_senator_landing ? ' l-header__collapsed' : '' }}" style="z-index: 100;">
   <!-- Begin Header -->
   <div class="panel-pane pane-block pane-nys-blocks-sitewide-header-bar-block">
 


### PR DESCRIPTION
This PR resolves 2 JS issues that affect performance and stability of senator microsite sections:

1. The Drupal/PHP layer was rendering the same full size header on microsite interior pages (Event, Press Release, etc) as on the full senator landing page, hidden by CSS. Then, using JS, the theme was manipulating that full header into the collapsed header users saw. This PR ensures the interior page collapsed header is rendered correctly by default, and that JS is only needed for additional UX enhancements. This way, any issues in the JS-layer won't break the interior pages headers.
2. JS code was cloning the senator image into place on each page scroll, leading to potential performance issues and visual glitches. This PR clones the senator image once at an earlier rendering stage, removing the issue.