### PR TITLE
NYS-101: Fix issue explorer not loading for anonymous users

### DIFF
--- a/config/sync/views.view.issues_listings.yml
+++ b/config/sync/views.view.issues_listings.yml
@@ -495,6 +495,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -871,56 +872,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        link_flag:
-          id: link_flag
-          table: flagging
-          field: link_flag
-          relationship: flag_relationship
-          group_type: group
-          admin_label: ''
-          entity_type: flagging
-          plugin_id: flag_link
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
       pager:
         type: infinite_scroll
         options:
@@ -978,6 +929,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -1057,10 +1009,12 @@ display:
       defaults:
         access: false
         pager: false
+        relationships: false
         fields: false
         sorts: false
         filters: false
         filter_groups: false
+      relationships: {  }
       display_description: ''
       exposed_block: true
       display_extenders: {  }
@@ -1316,6 +1270,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -1999,6 +1954,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -2330,6 +2286,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -2720,6 +2677,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -3063,6 +3021,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -3358,6 +3317,7 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+          accept_null: false
         vid:
           id: vid
           table: taxonomy_term_field_data


### PR DESCRIPTION
This PR fixes the issue of the issues explorer page (/explore-issues) not loading--or loading very slowly--for anonymous users by removing an unused flag field and relationship from one of the views on that page.