### PR TITLE
NYS-107: Fix bug where wrong bill targeted when multiple bill vote widgets are on same page

### DIFF
--- a/web/modules/custom/nys_bill_vote/src/Form/BillVoteWidgetForm.php
+++ b/web/modules/custom/nys_bill_vote/src/Form/BillVoteWidgetForm.php
@@ -345,12 +345,7 @@ class BillVoteWidgetForm extends FormBase {
     $value = $triggering_element['#value'];
     $id = $triggering_element['#id'];
 
-    if (!empty($user_input['nid'])) {
-      $bill_path = '/node/' . $user_input['nid'];
-    }
-    else {
-      $bill_path = '/node/' . $settings['entity_id'];
-    }
+    $bill_path = '/node/' . (empty($user_input['nid']) ? $settings['entity_id'] : $user_input['nid']);
 
     $intent = $this->billVoteHelper->getIntentFromVote($value);
 

--- a/web/modules/custom/nys_bill_vote/src/Form/BillVoteWidgetForm.php
+++ b/web/modules/custom/nys_bill_vote/src/Form/BillVoteWidgetForm.php
@@ -340,11 +340,17 @@ class BillVoteWidgetForm extends FormBase {
     }
 
     $settings = $form_state->getBuildInfo();
+    $user_input = $form_state->getUserInput();
     $triggering_element = $form_state->getTriggeringElement();
     $value = $triggering_element['#value'];
     $id = $triggering_element['#id'];
 
-    $bill_path = '/node/' . $settings['entity_id'];
+    if (!empty($user_input['nid'])) {
+      $bill_path = '/node/' . $user_input['nid'];
+    }
+    else {
+      $bill_path = '/node/' . $settings['entity_id'];
+    }
 
     $intent = $this->billVoteHelper->getIntentFromVote($value);
 


### PR DESCRIPTION
Steps to reproduce:
1. Log in as an authenticated user
2. Navigate to: https://www.nysenate.gov/newsroom/press-releases/2024/senate-bolsters-educator-diversity-efforts-new-york-state
3. Click “Aye“ under bill “2023-S1988“
4. Result: Redirected to bill “2023-S3385A“
5. Expected result: Redirected to bill “2023-S1988“

**Technical note for @routinet and @aheaphy:** this fixes a bug in the BillVoteWidgetForm::voteAjaxCallback method by getting the bill ID from the form input (which is always correct) vs. the form build info (which is incorrect in contexts where there are multiple vote widgets present). There may still be an underlying bug on the form build stage, but I avoided larger refactors there as I know we plan to rework this form anyways.