### PR TITLE
Uncheck privacy consent policy for google tags

### DIFF
--- a/config/sync/gin.settings.yml
+++ b/config/sync/gin.settings.yml
@@ -19,7 +19,7 @@ preset_accent_color: custom
 preset_focus_color: custom
 enable_darkmode: '0'
 classic_toolbar: horizontal
-secondary_toolbar_frontend: true
+secondary_toolbar_frontend: false
 high_contrast_mode: true
 accent_color: '#2b6a90'
 focus_color: '#cb8d37'

--- a/config/sync/google_tag.container.G-01H6J3L7N6.656e09e463cc88.61658280.yml
+++ b/config/sync/google_tag.container.G-01H6J3L7N6.656e09e463cc88.61658280.yml
@@ -7,17 +7,18 @@ label: G-01H6J3L7N6
 weight: 0
 tag_container_ids:
   - G-01H6J3L7N6
-advanced_settings: null
+advanced_settings:
+  consent_mode: false
 dimensions_metrics: {  }
 conditions: {  }
 events:
-  webform_purchase: {  }
-  search: {  }
-  custom: {  }
   sign_up:
     method: CMS
-  login:
-    method: CMS
+  custom: {  }
+  webform_purchase: {  }
+  search: {  }
   generate_lead:
     value: ''
     currency: ''
+  login:
+    method: CMS


### PR DESCRIPTION
PLUS: removes gin sub tool bar from frontend (which is already done on live, so need it in config too)