### PR TITLE
NYS-16492: public hearing updates not importing

### DIFF
--- a/web/modules/custom/nys_openleg_api/src/Plugin/OpenlegApi/Response/PublicHearingUpdateList.php
+++ b/web/modules/custom/nys_openleg_api/src/Plugin/OpenlegApi/Response/PublicHearingUpdateList.php
@@ -6,7 +6,7 @@ namespace Drupal\nys_openleg_api\Plugin\OpenlegApi\Response;
  * Openleg API Response plugin for a list of public hearing transcript updates.
  *
  * @OpenlegApiResponse(
- *   id = "public_hearing-update-token list",
+ *   id = "hearing-update-token list",
  *   label = @Translation("Public Hearing Update List"),
  *   description = @Translation("Openleg API Response plugin")
  * )
@@ -18,15 +18,15 @@ class PublicHearingUpdateList extends ResponseUpdate {
    */
   public function listIds(): array {
     return array_unique(
-          array_filter(
-              array_map(
-                  function ($v) {
-                        return $v->publicHearingId->id ?? '';
-                  },
-                  $this->items()
-              )
-          )
-      );
+      array_filter(
+        array_map(
+          function ($v) {
+            return $v->hearingId->id ?? '';
+          },
+          $this->items()
+        )
+      )
+    );
   }
 
 }


### PR DESCRIPTION
  - Clean up usage of raw vs resolved command-line options
  - Implement OL API changes to public hearing returns
  - Address Drush's removal of success/fail constants
  - Clean up old sniffer canary (yay! it's working!)