### PR TITLE
Update core 10.3.2, update contrib modules, fix custom modules for d11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.7.0",
         "dompdf/dompdf": "^2.0",
+        "drupal/action": "^0.2",
         "drupal/address": "^2.0",
         "drupal/address_map_link": "^1.4",
         "drupal/admin_toolbar": "^3.0",
@@ -67,7 +68,7 @@
         "drupal/eva": "^3.0",
         "drupal/facets": "^2.0",
         "drupal/fancy_file_delete": "^2.0",
-        "drupal/field_group": "^3.4",
+        "drupal/field_group": "3.4",
         "drupal/field_permissions": "^1.1",
         "drupal/field_validation": "^1.0@beta",
         "drupal/filefield_paths": "^1.0@beta",
@@ -284,14 +285,13 @@
                 "2769407 - Views UI should offer a 'Treat NULL values as FALSE' on boolean field": "https://www.drupal.org/files/issues/2024-06-26/2769407_views_ui_null_option-10.3.x-90.patch",
                 "2741877 - Nested modals don't work - fixed focal point preview modal": "https://www.drupal.org/files/issues/2024-06-20/drupal-core--2024-06-20--2741877--mr-8105.patch",
                 "3049216 - ajax error": "https://www.drupal.org/files/issues/2023-01-31/3049216-21_0.patch",
-                "3315678 - strnatcasecmp(): Passing null to parameter #2 ($string2) of type string is deprecated": "https://www.drupal.org/files/issues/2023-01-30/categorizing_plugin_error-3315678-16.patch",
-                "3456738 - breaks log in": "https://www.drupal.org/files/issues/2024-06-25/3456738-9.patch"
+                "3315678 - strnatcasecmp(): Passing null to parameter #2 ($string2) of type string is deprecated": "https://www.drupal.org/files/issues/2023-01-30/categorizing_plugin_error-3315678-16.patch"
             },
             "drupal/htmlpurifier": {
                 "2989756 - HTMLPurifier Serializer caches into vendor directory by default": "https://www.drupal.org/files/issues/2021-09-24/serializer-caches-into-vendor-d9-2989756-14.patch"
             },
             "drupal/inline_entity_form": {
-                "3099844 - Required fields make an optional IEF (erroneously) required": "https://www.drupal.org/files/issues/2021-07-19/inline_entity_form-required_fields_optional_ief-3099844-24.patch"
+                "3099844 - Required fields make an optional IEF (erroneously) required": "https://www.drupal.org/files/issues/2024-02-01/inline_entity_form-required_fields_optional_ief-3099844-35.patch"
             },
             "drupal/votingapi": {
                 "#3192657-2: Update drush command declaration with regard to options": "https://www.drupal.org/files/issues/2022-07-07/votingapi-3294809.patch"
@@ -326,9 +326,6 @@
             },
             "drupal/clamav": {
                 "3383653 -Support image upload plugin for CKEditor5\n": "https://git.drupalcode.org/project/clamav/-/merge_requests/7.patch"
-            },
-            "drupal/email_registration": {
-                "3456461 - Login fails with Drupal 10.3": "https://git.drupalcode.org/project/email_registration/-/merge_requests/43.patch"
             },
             "drupal/stage_file_proxy": {
                 "3457368 - createProxyHeadersArray(): Argument #1 ($headers_string) must be of type string": "https://git.drupalcode.org/project/stage_file_proxy/-/merge_requests/74.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9b8ff3f5c63293e58abb4812baad690",
+    "content-hash": "172cdc3dce4a8056c4e3d00c4586a7b2",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1219,16 +1219,16 @@
         },
         {
             "name": "dflydev/dot-access-data",
-            "version": "v3.0.2",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
-                "reference": "f41715465d65213d644d3141a6a93081be5d3549"
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/f41715465d65213d644d3141a6a93081be5d3549",
-                "reference": "f41715465d65213d644d3141a6a93081be5d3549",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/a23a2bf4f31d3518f3ecb38660c95715dfead60f",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f",
                 "shasum": ""
             },
             "require": {
@@ -1288,9 +1288,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
-                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.2"
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
-            "time": "2022-10-27T11:44:00+00:00"
+            "time": "2024-07-08T12:26:09+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -1806,20 +1806,20 @@
         },
         {
             "name": "drupal/admin_toolbar",
-            "version": "3.4.2",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/admin_toolbar.git",
-                "reference": "3.4.2"
+                "reference": "3.5.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/admin_toolbar-3.4.2.zip",
-                "reference": "3.4.2",
-                "shasum": "f5a008e5c73f5a11c6c8067c0ea6ebb76aa33854"
+                "url": "https://ftp.drupal.org/files/projects/admin_toolbar-3.5.0.zip",
+                "reference": "3.5.0",
+                "shasum": "099e8d4dc98e1d551b4f9cffdc39599eb8ad04e8"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^9.5 || ^10 || ^11"
             },
             "require-dev": {
                 "drupal/admin_toolbar_tools": "*"
@@ -1827,8 +1827,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.4.2",
-                    "datestamp": "1696006195",
+                    "version": "3.5.0",
+                    "datestamp": "1722639094",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -1860,6 +1860,10 @@
                     "name": "Mohamed Anis Taktak (matio89)",
                     "homepage": "https://www.drupal.org/u/matio89",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
                 },
                 {
                     "name": "matio89",
@@ -1959,20 +1963,20 @@
         },
         {
             "name": "drupal/allowed_formats",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/allowed_formats.git",
-                "reference": "3.0.0"
+                "reference": "3.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/allowed_formats-3.0.0.zip",
-                "reference": "3.0.0",
-                "shasum": "1dad855db0e12fa3cdef8ca4e3bfc98f89090490"
+                "url": "https://ftp.drupal.org/files/projects/allowed_formats-3.0.1.zip",
+                "reference": "3.0.1",
+                "shasum": "9dfaed3ab8425ee94146914fdb492cefc6c6bb4d"
             },
             "require": {
-                "drupal/core": "^10.1"
+                "drupal/core": "^10.1 || ^11"
             },
             "conflict": {
                 "drupal/core": "<10.1.0"
@@ -1980,8 +1984,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.0",
-                    "datestamp": "1693983469",
+                    "version": "3.0.1",
+                    "datestamp": "1723158950",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2023,17 +2027,17 @@
         },
         {
             "name": "drupal/auto_entitylabel",
-            "version": "3.2.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/auto_entitylabel.git",
-                "reference": "8.x-3.2"
+                "reference": "8.x-3.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/auto_entitylabel-8.x-3.2.zip",
-                "reference": "8.x-3.2",
-                "shasum": "0229f2264984e9f33ba339577695dddd3613fd99"
+                "url": "https://ftp.drupal.org/files/projects/auto_entitylabel-8.x-3.3.zip",
+                "reference": "8.x-3.3",
+                "shasum": "38fd79973a7b49441bf622a1429a7c6623b93035"
             },
             "require": {
                 "drupal/core": "^10.1 || ^11"
@@ -2044,8 +2048,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.2",
-                    "datestamp": "1717752307",
+                    "version": "8.x-3.3",
+                    "datestamp": "1723462798",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2334,26 +2338,26 @@
         },
         {
             "name": "drupal/block_field",
-            "version": "1.0.0-rc4",
+            "version": "1.0.0-rc5",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/block_field.git",
-                "reference": "8.x-1.0-rc4"
+                "reference": "8.x-1.0-rc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/block_field-8.x-1.0-rc4.zip",
-                "reference": "8.x-1.0-rc4",
-                "shasum": "97958ceace8ca80852f40b734ff7197e172d726e"
+                "url": "https://ftp.drupal.org/files/projects/block_field-8.x-1.0-rc5.zip",
+                "reference": "8.x-1.0-rc5",
+                "shasum": "b87e43e9bbaaf6cff6d8946d5e45db492978cbb6"
             },
             "require": {
-                "drupal/core": "^9 || ^10"
+                "drupal/core": "^9 || ^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.0-rc4",
-                    "datestamp": "1667511464",
+                    "version": "8.x-1.0-rc5",
+                    "datestamp": "1723550576",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -2370,7 +2374,7 @@
                     "homepage": "https://www.drupal.org/user/1036766"
                 },
                 {
-                    "name": "Berdir",
+                    "name": "berdir",
                     "homepage": "https://www.drupal.org/user/214652"
                 },
                 {
@@ -3257,16 +3261,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "10.3.1",
+            "version": "10.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "d137403a30d4154404e473785f48dfc889d77e23"
+                "reference": "10e79c67a903844bef02a5cf10475d9a8b623e7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/d137403a30d4154404e473785f48dfc889d77e23",
-                "reference": "d137403a30d4154404e473785f48dfc889d77e23",
+                "url": "https://api.github.com/repos/drupal/core/zipball/10e79c67a903844bef02a5cf10475d9a8b623e7a",
+                "reference": "10e79c67a903844bef02a5cf10475d9a8b623e7a",
                 "shasum": ""
             },
             "require": {
@@ -3415,13 +3419,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/10.3.1"
+                "source": "https://github.com/drupal/core/tree/10.3.2"
             },
-            "time": "2024-07-04T11:33:45+00:00"
+            "time": "2024-08-08T09:23:57+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "10.3.1",
+            "version": "10.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -3465,13 +3469,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/10.3.1"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/10.3.2"
             },
             "time": "2024-05-11T08:21:39+00:00"
         },
         {
             "name": "drupal/core-project-message",
-            "version": "10.3.1",
+            "version": "10.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-project-message.git",
@@ -3506,22 +3510,22 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-project-message/tree/11.0.0-beta1"
+                "source": "https://github.com/drupal/core-project-message/tree/11.0.1"
             },
             "time": "2023-07-24T07:55:25+00:00"
         },
         {
             "name": "drupal/core-recommended",
-            "version": "10.3.1",
+            "version": "10.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "a5183f2be315b7e5deec89fdeafe9fc9a2e54f57"
+                "reference": "18b7288d2e661afadfff4a714c5a166bf2554124"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/a5183f2be315b7e5deec89fdeafe9fc9a2e54f57",
-                "reference": "a5183f2be315b7e5deec89fdeafe9fc9a2e54f57",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/18b7288d2e661afadfff4a714c5a166bf2554124",
+                "reference": "18b7288d2e661afadfff4a714c5a166bf2554124",
                 "shasum": ""
             },
             "require": {
@@ -3530,7 +3534,7 @@
                 "doctrine/annotations": "~1.14.3",
                 "doctrine/deprecations": "~1.1.3",
                 "doctrine/lexer": "~2.1.1",
-                "drupal/core": "10.3.1",
+                "drupal/core": "10.3.2",
                 "egulias/email-validator": "~4.0.2",
                 "guzzlehttp/guzzle": "~7.8.1",
                 "guzzlehttp/promises": "~2.0.2",
@@ -3591,9 +3595,9 @@
             ],
             "description": "Core and its dependencies with known-compatible minor versions. Require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/10.3.1"
+                "source": "https://github.com/drupal/core-recommended/tree/10.3.2"
             },
-            "time": "2024-07-04T11:33:45+00:00"
+            "time": "2024-08-08T09:23:57+00:00"
         },
         {
             "name": "drupal/crop",
@@ -4020,35 +4024,33 @@
         },
         {
             "name": "drupal/email_registration",
-            "version": "2.0.0-rc5",
+            "version": "2.0.0-rc7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/email_registration.git",
-                "reference": "2.0.0-rc5"
+                "reference": "2.0.0-rc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/email_registration-2.0.0-rc5.zip",
-                "reference": "2.0.0-rc5",
-                "shasum": "2a9153db2dd42541a2c223a8f3e0dbecf047ead4"
+                "url": "https://ftp.drupal.org/files/projects/email_registration-2.0.0-rc7.zip",
+                "reference": "2.0.0-rc7",
+                "shasum": "3a6a9516cdf530df630b6cdc8b8c2c42e3170858"
             },
             "require": {
-                "drupal/core": "^9.1 || ^10"
+                "drupal/core": "^9.5 || ^10 || ^11"
             },
             "conflict": {
                 "drupal/commerce": "<2.12"
             },
             "require-dev": {
                 "drupal/commerce": "^2.0",
-                "drupal/drupal-extension": "^5.0",
-                "drupal/token": "*",
-                "friends-of-behat/service-container-extension": "^1.0"
+                "drupal/token": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-rc5",
-                    "datestamp": "1713019621",
+                    "version": "2.0.0-rc7",
+                    "datestamp": "1722882404",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -4151,21 +4153,21 @@
         },
         {
             "name": "drupal/entity_print",
-            "version": "2.14.0",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_print.git",
-                "reference": "8.x-2.14"
+                "reference": "8.x-2.15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_print-8.x-2.14.zip",
-                "reference": "8.x-2.14",
-                "shasum": "5ecc2c11ed839dd870ab5127e5e83cc4c3783801"
+                "url": "https://ftp.drupal.org/files/projects/entity_print-8.x-2.15.zip",
+                "reference": "8.x-2.15",
+                "shasum": "76ba73f443525ab5b233eae925f22f88c9663b8f"
             },
             "require": {
                 "dompdf/dompdf": ">=2.0.7",
-                "drupal/core": "^9.4 || ^10.0"
+                "drupal/core": "^9.4 || ^10.0 || ^11"
             },
             "suggest": {
                 "mikehaertl/phpwkhtmltopdf": "PhpWkhtmlToPdf provides the PHP library to use Wkhtmltopdf"
@@ -4173,8 +4175,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.14",
-                    "datestamp": "1713939908",
+                    "version": "8.x-2.15",
+                    "datestamp": "1722642740",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4193,6 +4195,10 @@
                 {
                     "name": "benjy",
                     "homepage": "https://www.drupal.org/user/1852732"
+                },
+                {
+                    "name": "jsacksick",
+                    "homepage": "https://www.drupal.org/user/972218"
                 },
                 {
                     "name": "larowlan",
@@ -4225,29 +4231,29 @@
         },
         {
             "name": "drupal/entity_reference_revisions",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_reference_revisions.git",
-                "reference": "8.x-1.11"
+                "reference": "8.x-1.12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_reference_revisions-8.x-1.11.zip",
-                "reference": "8.x-1.11",
-                "shasum": "de21cbb0d8a0344dc3496addcad4ed536747cec5"
+                "url": "https://ftp.drupal.org/files/projects/entity_reference_revisions-8.x-1.12.zip",
+                "reference": "8.x-1.12",
+                "shasum": "2a2ff8617c7ce01b56df1caaf0a563da04948e26"
             },
             "require": {
-                "drupal/core": "^9 || ^10"
+                "drupal/core": "^9 || ^10 || ^11"
             },
             "require-dev": {
-                "drupal/diff": "1.x-dev"
+                "drupal/diff": "^1 || ^2"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.11",
-                    "datestamp": "1705140721",
+                    "version": "8.x-1.12",
+                    "datestamp": "1722804497",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4462,28 +4468,28 @@
         },
         {
             "name": "drupal/facets",
-            "version": "2.0.7",
+            "version": "2.0.8",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/facets.git",
-                "reference": "2.0.7"
+                "reference": "2.0.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/facets-2.0.7.zip",
-                "reference": "2.0.7",
-                "shasum": "a58ad0c4c3fc2750bf095232a54218ae906852e3"
+                "url": "https://ftp.drupal.org/files/projects/facets-2.0.8.zip",
+                "reference": "2.0.8",
+                "shasum": "ab46542fe36e05697a5562fe504d1f61986eb268"
             },
             "require": {
-                "drupal/core": "^9.3 || ^10.0"
+                "drupal/core": "^10 || ^11"
             },
             "conflict": {
-                "drupal/search_api": "<1.14"
+                "drupal/search_api": "<1.30"
             },
             "require-dev": {
-                "drupal/jquery_ui_slider": "~2.0",
-                "drupal/jquery_ui_touch_punch": "~1.1",
-                "drupal/search_api": "^1.28||1.x-dev"
+                "drupal/jquery_ui_slider": "^2.1",
+                "drupal/jquery_ui_touch_punch": "^1.1",
+                "drupal/search_api": "1.x-dev"
             },
             "suggest": {
                 "drupal/jquery_ui_slider": "Required for the 'Facets Range Widget' module to work",
@@ -4492,8 +4498,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.7",
-                    "datestamp": "1709900263",
+                    "version": "2.0.8",
+                    "datestamp": "1723040927",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5130,26 +5136,26 @@
         },
         {
             "name": "drupal/fullcalendar_view",
-            "version": "5.1.14",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/fullcalendar_view.git",
-                "reference": "5.1.14"
+                "reference": "5.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/fullcalendar_view-5.1.14.zip",
-                "reference": "5.1.14",
-                "shasum": "b1815f87b1f931fa55cf9b46f6ca11a438ac0691"
+                "url": "https://ftp.drupal.org/files/projects/fullcalendar_view-5.2.1.zip",
+                "reference": "5.2.1",
+                "shasum": "e1424d4f701f4f90b6c006f9de2a5488efaa4d81"
             },
             "require": {
-                "drupal/core": "^9.2.0 || ^10"
+                "drupal/core": "^9.2.0 || ^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "5.1.14",
-                    "datestamp": "1712463968",
+                    "version": "5.2.1",
+                    "datestamp": "1723181912",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5166,7 +5172,7 @@
                     "homepage": "https://www.drupal.org/user/787114"
                 },
                 {
-                    "name": "Mingsong",
+                    "name": "mingsong",
                     "homepage": "https://www.drupal.org/user/2986445"
                 }
             ],
@@ -5183,17 +5189,17 @@
         },
         {
             "name": "drupal/geocoder",
-            "version": "4.24.0",
+            "version": "4.25.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/geocoder.git",
-                "reference": "8.x-4.24"
+                "reference": "8.x-4.25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/geocoder-8.x-4.24.zip",
-                "reference": "8.x-4.24",
-                "shasum": "b3aafd2d6f0dcda14e383286b23a5bc6fd62fc10"
+                "url": "https://ftp.drupal.org/files/projects/geocoder-8.x-4.25.zip",
+                "reference": "8.x-4.25",
+                "shasum": "f62dcbdb3c27a266aed92f78c6b861ffaa391ff0"
             },
             "require": {
                 "davedevelopment/stiphle": "^0.9.2",
@@ -5237,8 +5243,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-4.24",
-                    "datestamp": "1719606014",
+                    "version": "8.x-4.25",
+                    "datestamp": "1722204762",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5538,21 +5544,20 @@
         },
         {
             "name": "drupal/google_tag",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/google_tag.git",
-                "reference": "2.0.5"
+                "reference": "2.0.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/google_tag-2.0.5.zip",
-                "reference": "2.0.5",
-                "shasum": "75f5cbdf8ea8c78178a5dfab50cf7ee7777c6491"
+                "url": "https://ftp.drupal.org/files/projects/google_tag-2.0.6.zip",
+                "reference": "2.0.6",
+                "shasum": "c8f2895a81a7898ac909bdc693fcd25ffe6f62be"
             },
             "require": {
-                "drupal/core": "^9.5 || ^10",
-                "php": "^7.4 || ^8"
+                "drupal/core": "^9.5 || ^10 || ^11"
             },
             "require-dev": {
                 "drupal/commerce": "^2.0",
@@ -5566,8 +5571,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.5",
-                    "datestamp": "1716308134",
+                    "version": "2.0.6",
+                    "datestamp": "1721948116",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5603,7 +5608,7 @@
                     "homepage": "https://www.drupal.org/user/240748"
                 }
             ],
-            "description": "Sets up Google Tag",
+            "description": "Provides support for Google Tag and Google Tag Manager in Drupal.",
             "homepage": "https://www.drupal.org/project/google_tag",
             "support": {
                 "source": "https://git.drupalcode.org/project/google_tag"
@@ -5701,29 +5706,29 @@
         },
         {
             "name": "drupal/honeypot",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/honeypot.git",
-                "reference": "2.1.3"
+                "reference": "2.1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.3.zip",
-                "reference": "2.1.3",
-                "shasum": "101105029a10a574ef6017824182500ab9905856"
+                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.4.zip",
+                "reference": "2.1.4",
+                "shasum": "adf76c3520c0e458177dbe6d638aa2d6ae40a95b"
             },
             "require": {
                 "drupal/core": "^9.2 || ^10"
             },
             "require-dev": {
-                "drupal/rules": "^3.0"
+                "drupal/rules": "^3.x-dev"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.1.3",
-                    "datestamp": "1695604754",
+                    "version": "2.1.4",
+                    "datestamp": "1723489062",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6048,20 +6053,21 @@
         },
         {
             "name": "drupal/inline_entity_form",
-            "version": "3.0.0-rc19",
+            "version": "3.0.0-rc20",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/inline_entity_form.git",
-                "reference": "3.0.0-rc19"
+                "reference": "3.0.0-rc20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-3.0.0-rc19.zip",
-                "reference": "3.0.0-rc19",
-                "shasum": "d8976940dd3f85412ba5e274af15fbcdd22ee27a"
+                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-3.0.0-rc20.zip",
+                "reference": "3.0.0-rc20",
+                "shasum": "c9ad4572bce4260d1d233a0c3196e4ff0915e4ee"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9 || ^10",
+                "drupal/core": "^8.8 || ^9 || ^10 || ^11",
+                "drupal/rat": "^1.0.0@stable",
                 "php": ">=7.1"
             },
             "require-dev": {
@@ -6070,8 +6076,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.0-rc19",
-                    "datestamp": "1704729077",
+                    "version": "3.0.0-rc20",
+                    "datestamp": "1722000368",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -6795,17 +6801,17 @@
         },
         {
             "name": "drupal/login_history",
-            "version": "2.0.0-alpha3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/login_history.git",
-                "reference": "2.0.0-alpha3"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/login_history-2.0.0-alpha3.zip",
-                "reference": "2.0.0-alpha3",
-                "shasum": "753605f5a8ddca96fcc2b631ca832d01c8dbc453"
+                "url": "https://ftp.drupal.org/files/projects/login_history-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "220ee8e159bcf8340ee9a9b42a7a6dd722b87359"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10 || ^11"
@@ -6813,11 +6819,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-alpha3",
-                    "datestamp": "1718443601",
+                    "version": "2.0.0",
+                    "datestamp": "1722358059",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -6929,26 +6935,26 @@
         },
         {
             "name": "drupal/mailsystem",
-            "version": "4.4.0",
+            "version": "4.5.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/mailsystem.git",
-                "reference": "8.x-4.4"
+                "reference": "8.x-4.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/mailsystem-8.x-4.4.zip",
-                "reference": "8.x-4.4",
-                "shasum": "49b2e9efd090cdb4a282c7638b1c76d6723c47b6"
+                "url": "https://ftp.drupal.org/files/projects/mailsystem-8.x-4.5.zip",
+                "reference": "8.x-4.5",
+                "shasum": "e52a814a87b343ab69f8d8ef462a9873c1d01158"
             },
             "require": {
-                "drupal/core": "^9 || ^10"
+                "drupal/core": "^9 || ^10.1 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-4.4",
-                    "datestamp": "1657576306",
+                    "version": "8.x-4.5",
+                    "datestamp": "1723379369",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6961,7 +6967,7 @@
             ],
             "authors": [
                 {
-                    "name": "Berdir",
+                    "name": "berdir",
                     "homepage": "https://www.drupal.org/user/214652"
                 },
                 {
@@ -7411,42 +7417,45 @@
         },
         {
             "name": "drupal/metatag",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/metatag.git",
-                "reference": "2.0.0"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/metatag-2.0.0.zip",
-                "reference": "2.0.0",
-                "shasum": "2966c854d982b7069b1c0111519427990ebbad40"
+                "url": "https://ftp.drupal.org/files/projects/metatag-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "748013c50a0ed5e10359413bb3481392a0bf0d3f"
             },
             "require": {
-                "drupal/core": "^9.4 || ^10",
+                "drupal/core": "^9.4 || ^10 || ^11",
                 "drupal/token": "^1.0",
                 "php": ">=8.0"
             },
             "require-dev": {
-                "drupal/devel": "^4.0 || ^5.0",
-                "drupal/hal": "^9 || ^1 || ^2",
+                "drupal/hal": "^1 || ^2 || ^9",
                 "drupal/metatag_dc": "*",
                 "drupal/metatag_open_graph": "*",
                 "drupal/page_manager": "^4.0",
                 "drupal/redirect": "^1.0",
-                "drupal/webprofiler": "^9 || ^10",
+                "ergebnis/composer-normalize": "*",
                 "mpyw/phpunit-patch-serializable-comparison": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0",
-                    "datestamp": "1692368265",
+                    "version": "2.0.2",
+                    "datestamp": "1722869772",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -8405,20 +8414,20 @@
         },
         {
             "name": "drupal/paragraphs",
-            "version": "1.17.0",
+            "version": "1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/paragraphs.git",
-                "reference": "8.x-1.17"
+                "reference": "8.x-1.18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.17.zip",
-                "reference": "8.x-1.17",
-                "shasum": "81c05f6a1eb59ab957c9ac97b2e79d6c9837bd72"
+                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.18.zip",
+                "reference": "8.x-1.18",
+                "shasum": "594e2937ea5c95fc88b60420590c4d83f5cd71ee"
             },
             "require": {
-                "drupal/core": "^9.3 || ^10",
+                "drupal/core": "^10.2 || ^11",
                 "drupal/entity_reference_revisions": "~1.3"
             },
             "require-dev": {
@@ -8426,6 +8435,7 @@
                 "drupal/diff": "1.x-dev",
                 "drupal/entity_browser": "2.x-dev",
                 "drupal/entity_usage": "2.x-dev",
+                "drupal/feeds": "^3",
                 "drupal/field_group": "3.x-dev",
                 "drupal/inline_entity_form": "1.x-dev",
                 "drupal/paragraphs-paragraphs_library": "*",
@@ -8439,8 +8449,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.17",
-                    "datestamp": "1709804220",
+                    "version": "8.x-1.18",
+                    "datestamp": "1723029144",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8553,26 +8563,26 @@
         },
         {
             "name": "drupal/password_policy",
-            "version": "4.0.1",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/password_policy.git",
-                "reference": "4.0.1"
+                "reference": "4.0.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/password_policy-4.0.1.zip",
-                "reference": "4.0.1",
-                "shasum": "a132988f77d02c28d5c0f8f6c84a2d37eaa36c1f"
+                "url": "https://ftp.drupal.org/files/projects/password_policy-4.0.3.zip",
+                "reference": "4.0.3",
+                "shasum": "f583ede0ebd749459538d02dd527028d57a4e1ac"
             },
             "require": {
-                "drupal/core": "^9.1 || ^10"
+                "drupal/core": "^9.1 || ^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.0.1",
-                    "datestamp": "1712532453",
+                    "version": "4.0.3",
+                    "datestamp": "1723552706",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8611,6 +8621,10 @@
                 {
                     "name": "shrop",
                     "homepage": "https://www.drupal.org/user/14767"
+                },
+                {
+                    "name": "vishalkhode",
+                    "homepage": "https://www.drupal.org/user/2439156"
                 }
             ],
             "description": "Sets up constraints and expiration of passwords.",
@@ -8622,22 +8636,25 @@
         },
         {
             "name": "drupal/pathauto",
-            "version": "1.12.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/pathauto.git",
-                "reference": "8.x-1.12"
+                "reference": "8.x-1.13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.12.zip",
-                "reference": "8.x-1.12",
-                "shasum": "b7b6432e315e38e59a7c6cc117134326c580de4c"
+                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.13.zip",
+                "reference": "8.x-1.13",
+                "shasum": "e64b5a82cf1b8ab48bce400b21ae6fc99c8078fd"
             },
             "require": {
-                "drupal/core": "^9.3 || ^10",
+                "drupal/core": "^9.4 || ^10 || ^11",
                 "drupal/ctools": "*",
                 "drupal/token": "*"
+            },
+            "require-dev": {
+                "drupal/forum": "*"
             },
             "suggest": {
                 "drupal/redirect": "When installed Pathauto will provide a new \"Update Action\" in case your URLs change. This is the recommended update action and is considered the best practice for SEO and usability."
@@ -8645,8 +8662,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.12",
-                    "datestamp": "1712319355",
+                    "version": "8.x-1.13",
+                    "datestamp": "1722507672",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9228,18 +9245,51 @@
             }
         },
         {
+            "name": "drupal/rat",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/rat.git",
+                "reference": "28202b02262a39ac8dbbfd43696b67c0c8c46b71"
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "drupal/core": "^9.4",
+                "drupal/core-dev": "^9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\rat\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "gpl-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Merlin",
+                    "email": "merlin@geeks4change.net"
+                }
+            ],
+            "time": "2023-07-19T20:22:22+00:00"
+        },
+        {
             "name": "drupal/recaptcha",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/recaptcha.git",
-                "reference": "8.x-3.3"
+                "reference": "8.x-3.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/recaptcha-8.x-3.3.zip",
-                "reference": "8.x-3.3",
-                "shasum": "376331ed5a0761d5414d294d6778bce4c308d6d5"
+                "url": "https://ftp.drupal.org/files/projects/recaptcha-8.x-3.4.zip",
+                "reference": "8.x-3.4",
+                "shasum": "95fa7ac5dd064ea6a1c14fc4881778bf68200598"
             },
             "require": {
                 "drupal/captcha": "^1.15 || ^2.0",
@@ -9249,8 +9299,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.3",
-                    "datestamp": "1720755549",
+                    "version": "8.x-3.4",
+                    "datestamp": "1723563033",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9291,11 +9341,11 @@
                     "homepage": "https://www.drupal.org/user/395439"
                 },
                 {
-                    "name": "Liam Morland",
+                    "name": "liam morland",
                     "homepage": "https://www.drupal.org/user/493050"
                 },
                 {
-                    "name": "RobLoach",
+                    "name": "robloach",
                     "homepage": "https://www.drupal.org/user/61114"
                 },
                 {
@@ -9316,26 +9366,26 @@
         },
         {
             "name": "drupal/redirect",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/redirect.git",
-                "reference": "8.x-1.9"
+                "reference": "8.x-1.10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.9.zip",
-                "reference": "8.x-1.9",
-                "shasum": "2987de20f509e9f7cec8a0f81d3a6774f9b0ba3e"
+                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.10.zip",
+                "reference": "8.x-1.10",
+                "shasum": "9d72d7e0717dbdea3ab3306c5d6840da5bd3024c"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^9.2 || ^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.9",
-                    "datestamp": "1693393506",
+                    "version": "8.x-1.10",
+                    "datestamp": "1723277641",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9352,7 +9402,7 @@
                     "homepage": "https://www.drupal.org/user/214652"
                 },
                 {
-                    "name": "Dave Reid",
+                    "name": "dave reid",
                     "homepage": "https://www.drupal.org/user/53892"
                 },
                 {
@@ -9510,25 +9560,25 @@
         },
         {
             "name": "drupal/scheduler",
-            "version": "2.0.4",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/scheduler.git",
-                "reference": "2.0.4"
+                "reference": "2.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/scheduler-2.0.4.zip",
-                "reference": "2.0.4",
-                "shasum": "50ee56a90243363453dcdeeaf96dbd6cbec9b7c8"
+                "url": "https://ftp.drupal.org/files/projects/scheduler-2.1.0.zip",
+                "reference": "2.1.0",
+                "shasum": "aea0f1dc40cfbc75f470860998d773a8749bcee2"
             },
             "require": {
-                "drupal/core": "^8 || ^9 || ^10"
+                "drupal/core": "^8 || ^9 || ^10 || ^11"
             },
             "require-dev": {
-                "drupal/commerce": "^2.0",
+                "drupal/commerce": "^2 || ^3",
                 "drupal/devel_generate": ">=4",
-                "drupal/rules": "^3",
+                "drupal/rules": "^3 || ^4",
                 "drupal/workbench_moderation": "*",
                 "drupal/workbench_moderation_actions": "*",
                 "drush/drush": ">=9"
@@ -9536,8 +9586,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.4",
-                    "datestamp": "1719580022",
+                    "version": "2.1.0",
+                    "datestamp": "1723723795",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9787,23 +9837,23 @@
         },
         {
             "name": "drupal/search_api_solr",
-            "version": "4.3.4",
+            "version": "4.3.5",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/search_api_solr.git",
-                "reference": "4.3.4"
+                "reference": "4.3.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/search_api_solr-4.3.4.zip",
-                "reference": "4.3.4",
-                "shasum": "e3f4ded975d57d4fa1d57786dcd6174e97804f45"
+                "url": "https://ftp.drupal.org/files/projects/search_api_solr-4.3.5.zip",
+                "reference": "4.3.5",
+                "shasum": "c784ebc822c95f54bbfbf7b6cb1c369142f13311"
             },
             "require": {
                 "composer-runtime-api": ">=2.0",
                 "composer/semver": "^1.0|^3.0",
                 "consolidation/annotated-command": "^2.12|^4.1",
-                "drupal/core": "^10.1 || ^11.0",
+                "drupal/core": "^10.2 || ^11.0",
                 "drupal/search_api": "~1.34",
                 "ext-dom": "*",
                 "ext-json": "*",
@@ -9836,8 +9886,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.3.4",
-                    "datestamp": "1718742899",
+                    "version": "4.3.5",
+                    "datestamp": "1722332547",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -10893,26 +10943,29 @@
         },
         {
             "name": "drupal/token",
-            "version": "1.14.0",
+            "version": "1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/token.git",
-                "reference": "8.x-1.14"
+                "reference": "8.x-1.15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/token-8.x-1.14.zip",
-                "reference": "8.x-1.14",
-                "shasum": "df3cae709fcc1a99ac1111ce67a0d6af56d287d7"
+                "url": "https://ftp.drupal.org/files/projects/token-8.x-1.15.zip",
+                "reference": "8.x-1.15",
+                "shasum": "5916fbccc86458a5f51e71f832ac70ff4c84ebdf"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^9.2 || ^10 || ^11"
+            },
+            "require-dev": {
+                "drupal/book": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.14",
-                    "datestamp": "1713009399",
+                    "version": "8.x-1.15",
+                    "datestamp": "1722206211",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -11407,17 +11460,17 @@
         },
         {
             "name": "drupal/upgrade_status",
-            "version": "4.3.4",
+            "version": "4.3.5",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/upgrade_status.git",
-                "reference": "4.3.4"
+                "reference": "4.3.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/upgrade_status-4.3.4.zip",
-                "reference": "4.3.4",
-                "shasum": "4f4839fbda706784c36fc5abb61665032f46a55d"
+                "url": "https://ftp.drupal.org/files/projects/upgrade_status-4.3.5.zip",
+                "reference": "4.3.5",
+                "shasum": "353c17f14c855f5ba0fe48c6a4f6486360c066a7"
             },
             "require": {
                 "dekor/php-array-table": "^2.0",
@@ -11434,8 +11487,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.3.4",
-                    "datestamp": "1720121263",
+                    "version": "4.3.5",
+                    "datestamp": "1723044184",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -12328,17 +12381,17 @@
         },
         {
             "name": "drupal/viewsreference",
-            "version": "2.0.0-beta8",
+            "version": "2.0.0-beta9",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/viewsreference.git",
-                "reference": "8.x-2.0-beta8"
+                "reference": "8.x-2.0-beta9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/viewsreference-8.x-2.0-beta8.zip",
-                "reference": "8.x-2.0-beta8",
-                "shasum": "5a84a12d6350a1b6631634910faeaa13d1fb1b9c"
+                "url": "https://ftp.drupal.org/files/projects/viewsreference-8.x-2.0-beta9.zip",
+                "reference": "8.x-2.0-beta9",
+                "shasum": "3ccf5039a67a66a5530b12894b14c9391b01550f"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10 || ^11"
@@ -12346,11 +12399,14 @@
             "conflict": {
                 "drupal/viewsreferennce": "*"
             },
+            "require-dev": {
+                "drupal/views_ajax_history": "1.x-dev"
+            },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.0-beta8",
-                    "datestamp": "1717030540",
+                    "version": "8.x-2.0-beta9",
+                    "datestamp": "1722575139",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -12690,17 +12746,17 @@
         },
         {
             "name": "drupal/webform_views",
-            "version": "5.2.0",
+            "version": "5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/webform_views.git",
-                "reference": "8.x-5.2"
+                "reference": "8.x-5.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/webform_views-8.x-5.2.zip",
-                "reference": "8.x-5.2",
-                "shasum": "4baf154754ac4708dd6d8d17085037a722db88d9"
+                "url": "https://ftp.drupal.org/files/projects/webform_views-8.x-5.4.zip",
+                "reference": "8.x-5.4",
+                "shasum": "7fb229b3d0d400d84a7b25af6942872ca9ba8fed"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10.0",
@@ -12709,8 +12765,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-5.2",
-                    "datestamp": "1691641824",
+                    "version": "8.x-5.4",
+                    "datestamp": "1723680695",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -14687,20 +14743,20 @@
         },
         {
             "name": "mglaman/phpstan-drupal",
-            "version": "1.2.11",
+            "version": "1.2.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mglaman/phpstan-drupal.git",
-                "reference": "e624a4b64de5b91a0c56852635af2115e9a6e08c"
+                "reference": "346bdddda169a56b6ebb7dc17893f0ac8f33a4f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/e624a4b64de5b91a0c56852635af2115e9a6e08c",
-                "reference": "e624a4b64de5b91a0c56852635af2115e9a6e08c",
+                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/346bdddda169a56b6ebb7dc17893f0ac8f33a4f1",
+                "reference": "346bdddda169a56b6ebb7dc17893f0ac8f33a4f1",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0",
+                "php": "^8.1",
                 "phpstan/phpstan": "^1.10.56",
                 "phpstan/phpstan-deprecation-rules": "^1.1.4",
                 "symfony/finder": "^4.2 || ^5.0 || ^6.0 || ^7.0",
@@ -14771,7 +14827,7 @@
             "description": "Drupal extension and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/mglaman/phpstan-drupal/issues",
-                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.11"
+                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.12"
             },
             "funding": [
                 {
@@ -14787,7 +14843,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-10T17:22:10+00:00"
+            "time": "2024-08-07T21:15:21+00:00"
         },
         {
             "name": "mkalkbrenner/php-htmldiff-advanced",
@@ -15833,16 +15889,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.8",
+            "version": "1.11.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec"
+                "reference": "640410b32995914bde3eed26fa89552f9c2c082f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
-                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/640410b32995914bde3eed26fa89552f9c2c082f",
+                "reference": "640410b32995914bde3eed26fa89552f9c2c082f",
                 "shasum": ""
             },
             "require": {
@@ -15887,7 +15943,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-24T07:01:22+00:00"
+            "time": "2024-08-08T09:02:50+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -16891,16 +16947,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9"
+                "reference": "504974cbe43d05f83b201d6498c206f16fc0cdbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
-                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/504974cbe43d05f83b201d6498c206f16fc0cdbc",
+                "reference": "504974cbe43d05f83b201d6498c206f16fc0cdbc",
                 "shasum": ""
             },
             "require": {
@@ -16965,7 +17021,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.9"
+                "source": "https://github.com/symfony/console/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -16981,20 +17037,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:49:33+00:00"
+            "time": "2024-07-26T12:30:32+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "a4df9dfe5da2d177af6643610c7bee2cb76a9f5e"
+                "reference": "5caf9c5f6085f13b27d70a236b776c07e4a1c3eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/a4df9dfe5da2d177af6643610c7bee2cb76a9f5e",
-                "reference": "a4df9dfe5da2d177af6643610c7bee2cb76a9f5e",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5caf9c5f6085f13b27d70a236b776c07e4a1c3eb",
+                "reference": "5caf9c5f6085f13b27d70a236b776c07e4a1c3eb",
                 "shasum": ""
             },
             "require": {
@@ -17046,7 +17102,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.9"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -17062,7 +17118,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-19T10:45:28+00:00"
+            "time": "2024-07-26T07:32:07+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -17133,16 +17189,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "c9b7cc075b3ab484239855622ca05cb0b99c13ec"
+                "reference": "231f1b2ee80f72daa1972f7340297d67439224f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/c9b7cc075b3ab484239855622ca05cb0b99c13ec",
-                "reference": "c9b7cc075b3ab484239855622ca05cb0b99c13ec",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/231f1b2ee80f72daa1972f7340297d67439224f0",
+                "reference": "231f1b2ee80f72daa1972f7340297d67439224f0",
                 "shasum": ""
             },
             "require": {
@@ -17188,7 +17244,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.4.9"
+                "source": "https://github.com/symfony/error-handler/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -17204,7 +17260,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-21T16:04:15+00:00"
+            "time": "2024-07-26T12:30:32+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -17430,16 +17486,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v6.4.8",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "3ef977a43883215d560a2cecb82ec8e62131471c"
+                "reference": "af29198d87112bebdd397bd7735fbd115997824c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/3ef977a43883215d560a2cecb82ec8e62131471c",
-                "reference": "3ef977a43883215d560a2cecb82ec8e62131471c",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/af29198d87112bebdd397bd7735fbd115997824c",
+                "reference": "af29198d87112bebdd397bd7735fbd115997824c",
                 "shasum": ""
             },
             "require": {
@@ -17474,7 +17530,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.4.8"
+                "source": "https://github.com/symfony/finder/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -17490,20 +17546,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-07-24T07:06:38+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.8",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "27de8cc95e11db7a50b027e71caaab9024545947"
+                "reference": "117f1f20a7ade7bcea28b861fb79160a21a1e37b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/27de8cc95e11db7a50b027e71caaab9024545947",
-                "reference": "27de8cc95e11db7a50b027e71caaab9024545947",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/117f1f20a7ade7bcea28b861fb79160a21a1e37b",
+                "reference": "117f1f20a7ade7bcea28b861fb79160a21a1e37b",
                 "shasum": ""
             },
             "require": {
@@ -17551,7 +17607,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -17567,20 +17623,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-07-26T12:36:27+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "cc4a9bec6e1bdd2405f40277a68a6ed1bb393005"
+                "reference": "147e0daf618d7575b5007055340d09aece5cf068"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/cc4a9bec6e1bdd2405f40277a68a6ed1bb393005",
-                "reference": "cc4a9bec6e1bdd2405f40277a68a6ed1bb393005",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/147e0daf618d7575b5007055340d09aece5cf068",
+                "reference": "147e0daf618d7575b5007055340d09aece5cf068",
                 "shasum": ""
             },
             "require": {
@@ -17665,7 +17721,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.9"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -17681,7 +17737,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T11:48:06+00:00"
+            "time": "2024-07-26T14:52:04+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -18699,16 +18755,16 @@
         },
         {
             "name": "symfony/psr-http-message-bridge",
-            "version": "v6.4.8",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/psr-http-message-bridge.git",
-                "reference": "23a162bd446b93948a2c2f6909d80ad06195be10"
+                "reference": "89a24648d73e4eee30893b0da16abc454a65c53b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/23a162bd446b93948a2c2f6909d80ad06195be10",
-                "reference": "23a162bd446b93948a2c2f6909d80ad06195be10",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/89a24648d73e4eee30893b0da16abc454a65c53b",
+                "reference": "89a24648d73e4eee30893b0da16abc454a65c53b",
                 "shasum": ""
             },
             "require": {
@@ -18762,7 +18818,7 @@
                 "psr-7"
             ],
             "support": {
-                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v6.4.8"
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -18778,20 +18834,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:51:39+00:00"
+            "time": "2024-07-15T09:36:38+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.8",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "8a40d0f9b01f0fbb80885d3ce0ad6714fb603a58"
+                "reference": "aad19fe10753ba842f0d653a8db819c4b3affa87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/8a40d0f9b01f0fbb80885d3ce0ad6714fb603a58",
-                "reference": "8a40d0f9b01f0fbb80885d3ce0ad6714fb603a58",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/aad19fe10753ba842f0d653a8db819c4b3affa87",
+                "reference": "aad19fe10753ba842f0d653a8db819c4b3affa87",
                 "shasum": ""
             },
             "require": {
@@ -18845,7 +18901,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.8"
+                "source": "https://github.com/symfony/routing/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -18861,20 +18917,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-07-15T09:26:24+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "56ce31d19127e79647ac53387c7555bdcd5730ce"
+                "reference": "9a67fcf320561e96f94d62bbe0e169ac534a5718"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/56ce31d19127e79647ac53387c7555bdcd5730ce",
-                "reference": "56ce31d19127e79647ac53387c7555bdcd5730ce",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/9a67fcf320561e96f94d62bbe0e169ac534a5718",
+                "reference": "9a67fcf320561e96f94d62bbe0e169ac534a5718",
                 "shasum": ""
             },
             "require": {
@@ -18943,7 +18999,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.4.9"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -18959,7 +19015,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T07:59:05+00:00"
+            "time": "2024-07-26T13:13:26+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -19046,16 +19102,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7"
+                "reference": "ccf9b30251719567bfd46494138327522b9a9446"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/76792dbd99690a5ebef8050d9206c60c59e681d7",
-                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ccf9b30251719567bfd46494138327522b9a9446",
+                "reference": "ccf9b30251719567bfd46494138327522b9a9446",
                 "shasum": ""
             },
             "require": {
@@ -19112,7 +19168,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.9"
+                "source": "https://github.com/symfony/string/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -19128,7 +19184,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:25:38+00:00"
+            "time": "2024-07-22T10:21:14+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -19210,16 +19266,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "ee0a4d6a327a963aee094f730da238f7ea18cb01"
+                "reference": "bcf939a9d1acd7d2912e9474c0c3d7840a03cbcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/ee0a4d6a327a963aee094f730da238f7ea18cb01",
-                "reference": "ee0a4d6a327a963aee094f730da238f7ea18cb01",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/bcf939a9d1acd7d2912e9474c0c3d7840a03cbcd",
+                "reference": "bcf939a9d1acd7d2912e9474c0c3d7840a03cbcd",
                 "shasum": ""
             },
             "require": {
@@ -19287,7 +19343,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v6.4.9"
+                "source": "https://github.com/symfony/validator/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -19303,20 +19359,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-22T07:42:41+00:00"
+            "time": "2024-07-26T12:30:32+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "c31566e4ca944271cc8d8ac6887cbf31b8c6a172"
+                "reference": "a71cc3374f5fb9759da1961d28c452373b343dd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c31566e4ca944271cc8d8ac6887cbf31b8c6a172",
-                "reference": "c31566e4ca944271cc8d8ac6887cbf31b8c6a172",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/a71cc3374f5fb9759da1961d28c452373b343dd4",
+                "reference": "a71cc3374f5fb9759da1961d28c452373b343dd4",
                 "shasum": ""
             },
             "require": {
@@ -19372,7 +19428,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.4.9"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -19388,7 +19444,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-27T13:23:14+00:00"
+            "time": "2024-07-26T12:30:32+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -20317,30 +20373,38 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.4",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "04229f163664973f68f38f6f73d917799168ef24"
+                "reference": "ea4ab6f9580a4fd221e0418f2c357cdd39102a90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/04229f163664973f68f38f6f73d917799168ef24",
-                "reference": "04229f163664973f68f38f6f73d917799168ef24",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/ea4ab6f9580a4fd221e0418f2c357cdd39102a90",
+                "reference": "ea4ab6f9580a4fd221e0418f2c357cdd39102a90",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.8"
+            },
             "require-dev": {
-                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan": "^1.11.8",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^5"
+                "phpunit/phpunit": "^8 || ^9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
                     "dev-main": "3.x-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
                 }
             },
             "autoload": {
@@ -20368,7 +20432,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.4"
+                "source": "https://github.com/composer/pcre/tree/3.2.0"
             },
             "funding": [
                 {
@@ -20384,7 +20448,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-27T13:40:54+00:00"
+            "time": "2024-07-25T09:36:02+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -21012,7 +21076,7 @@
         },
         {
             "name": "drupal/core-dev",
-            "version": "10.3.1",
+            "version": "10.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-dev.git",
@@ -21062,36 +21126,39 @@
             ],
             "description": "require-dev dependencies from drupal/drupal; use in addition to drupal/core-recommended to run tests from drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-dev/tree/10.3.1"
+                "source": "https://github.com/drupal/core-dev/tree/10.3.2"
             },
             "time": "2024-07-04T10:19:29+00:00"
         },
         {
             "name": "drupal/devel",
-            "version": "5.2.1",
+            "version": "5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/devel.git",
-                "reference": "5.2.1"
+                "reference": "5.3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/devel-5.2.1.zip",
-                "reference": "5.2.1",
-                "shasum": "793861751e01092fe8bc7c0cd47589ebea2bb8df"
+                "url": "https://ftp.drupal.org/files/projects/devel-5.3.1.zip",
+                "reference": "5.3.1",
+                "shasum": "6a5f13bdf93dc5f7f194b6af847589ae15e37b63"
             },
             "require": {
                 "doctrine/common": "^2.7 || ^3.4",
-                "drupal/core": ">=10.0 <12.0.0-stable",
+                "drupal/core": "^10.3 || ^11 || ^12",
                 "php": ">=8.1",
-                "symfony/var-dumper": "^4 || ^5 || ^6"
+                "symfony/var-dumper": "^4 || ^5 || ^6 || ^7"
             },
             "conflict": {
+                "drupal/core": "<10.3",
                 "drush/drush": "<12.5.1",
                 "kint-php/kint": "<3"
             },
             "require-dev": {
-                "drush/drush": "^12.5.1"
+                "drush/drush": "^13",
+                "firephp/firephp-core": "^0.5.3",
+                "kint-php/kint": "^5.1"
             },
             "suggest": {
                 "kint-php/kint": "Kint provides an informative display of arrays/objects. Useful for debugging and developing."
@@ -21099,8 +21166,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "5.2.1",
-                    "datestamp": "1711328410",
+                    "version": "5.3.1",
+                    "datestamp": "1723258446",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -21327,16 +21394,16 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v3.25.3",
+            "version": "v3.25.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "983a87f4f8798a90ca3a25b0f300b8fda38df643"
+                "reference": "749f6c8e99a7fe51d096c2db656a4af9a46a6b5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/983a87f4f8798a90ca3a25b0f300b8fda38df643",
-                "reference": "983a87f4f8798a90ca3a25b0f300b8fda38df643",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/749f6c8e99a7fe51d096c2db656a4af9a46a6b5e",
+                "reference": "749f6c8e99a7fe51d096c2db656a4af9a46a6b5e",
                 "shasum": ""
             },
             "require": {
@@ -21365,9 +21432,9 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.25.3"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.25.4"
             },
-            "time": "2024-02-15T21:11:49+00:00"
+            "time": "2024-07-24T17:10:25+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -21436,23 +21503,23 @@
         },
         {
             "name": "lullabot/mink-selenium2-driver",
-            "version": "v1.7.3",
+            "version": "v1.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Lullabot/MinkSelenium2Driver.git",
-                "reference": "91445897dda062790a741003c9c85d9bb2f902cf"
+                "reference": "145fe8ed1fb611be7409b70d609f71b0285f4724"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Lullabot/MinkSelenium2Driver/zipball/91445897dda062790a741003c9c85d9bb2f902cf",
-                "reference": "91445897dda062790a741003c9c85d9bb2f902cf",
+                "url": "https://api.github.com/repos/Lullabot/MinkSelenium2Driver/zipball/145fe8ed1fb611be7409b70d609f71b0285f4724",
+                "reference": "145fe8ed1fb611be7409b70d609f71b0285f4724",
                 "shasum": ""
             },
             "require": {
                 "behat/mink": "^1.11@dev",
                 "ext-json": "*",
-                "lullabot/php-webdriver": "^2.0.5",
-                "php": ">=7.2"
+                "lullabot/php-webdriver": "^2.0.6",
+                "php": ">=8.1"
             },
             "replace": {
                 "behat/mink-selenium2-driver": "1.7.0"
@@ -21502,22 +21569,22 @@
                 "webdriver"
             ],
             "support": {
-                "source": "https://github.com/Lullabot/MinkSelenium2Driver/tree/v1.7.3"
+                "source": "https://github.com/Lullabot/MinkSelenium2Driver/tree/v1.7.4"
             },
-            "time": "2024-07-17T16:07:12+00:00"
+            "time": "2024-08-08T07:40:04+00:00"
         },
         {
             "name": "lullabot/php-webdriver",
-            "version": "v2.0.5",
+            "version": "v2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Lullabot/php-webdriver.git",
-                "reference": "b686c5fe74ae4f3d5f7ff6e45234d99562de9ff4"
+                "reference": "8c28db7151b8a73bd98861fe19972ac3f40184d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Lullabot/php-webdriver/zipball/b686c5fe74ae4f3d5f7ff6e45234d99562de9ff4",
-                "reference": "b686c5fe74ae4f3d5f7ff6e45234d99562de9ff4",
+                "url": "https://api.github.com/repos/Lullabot/php-webdriver/zipball/8c28db7151b8a73bd98861fe19972ac3f40184d2",
+                "reference": "8c28db7151b8a73bd98861fe19972ac3f40184d2",
                 "shasum": ""
             },
             "require": {
@@ -21550,9 +21617,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Lullabot/php-webdriver/issues",
-                "source": "https://github.com/Lullabot/php-webdriver/tree/v2.0.5"
+                "source": "https://github.com/Lullabot/php-webdriver/tree/v2.0.6"
             },
-            "time": "2024-07-17T15:21:54+00:00"
+            "time": "2024-08-05T13:00:46+00:00"
         },
         {
             "name": "micheh/phpcs-gitlab",
@@ -24777,16 +24844,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "6e03e4db9696e0cfcda6537177c2c03dc49c45c8"
+                "reference": "ad510515b11ba5291fdd59b25d70227bfac2d7ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/6e03e4db9696e0cfcda6537177c2c03dc49c45c8",
-                "reference": "6e03e4db9696e0cfcda6537177c2c03dc49c45c8",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/ad510515b11ba5291fdd59b25d70227bfac2d7ab",
+                "reference": "ad510515b11ba5291fdd59b25d70227bfac2d7ab",
                 "shasum": ""
             },
             "require": {
@@ -24839,7 +24906,7 @@
             "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v6.4.9"
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -24855,7 +24922,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-21T16:04:15+00:00"
+            "time": "2024-07-26T12:30:32+00:00"
         },
         {
             "name": "symfony/polyfill-php73",

--- a/config/sync/auto_entitylabel.settings.block_content.accordion.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.accordion.yml
@@ -4,8 +4,9 @@ status: 2
 pattern: 'Accordion: [block_content:field_title]'
 escape: false
 preserve_titles: false
+save: false
+chunk: 50
 dependencies:
   config:
     - block_content.type.accordion
-save: 0
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/auto_entitylabel.settings.block_content.embed.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.embed.yml
@@ -4,8 +4,9 @@ status: 2
 pattern: 'Embed: [block_content:field_title]'
 escape: false
 preserve_titles: false
+save: false
+chunk: 50
 dependencies:
   config:
     - block_content.type.embed
-save: 0
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/auto_entitylabel.settings.block_content.form.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.form.yml
@@ -4,8 +4,9 @@ status: 2
 pattern: 'Form: [block_content:field_title]'
 escape: false
 preserve_titles: false
+save: false
+chunk: 50
 dependencies:
   config:
     - block_content.type.form
-save: 0
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/auto_entitylabel.settings.block_content.hero.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.hero.yml
@@ -4,8 +4,9 @@ status: 2
 pattern: 'Hero: [block_content:field_title]'
 escape: false
 preserve_titles: false
+save: false
+chunk: 50
 dependencies:
   config:
     - block_content.type.hero
-save: 0
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/auto_entitylabel.settings.block_content.map.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.map.yml
@@ -4,8 +4,9 @@ status: 2
 pattern: 'Map: [block_content:field_title]'
 escape: false
 preserve_titles: false
+save: false
+chunk: 50
 dependencies:
   config:
     - block_content.type.map
-save: 0
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/auto_entitylabel.settings.block_content.media.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.media.yml
@@ -4,8 +4,9 @@ status: 2
 pattern: 'Media: [block_content:field_title]'
 escape: false
 preserve_titles: false
+save: false
+chunk: 50
 dependencies:
   config:
     - block_content.type.media
-save: 0
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/auto_entitylabel.settings.block_content.quote.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.quote.yml
@@ -4,8 +4,9 @@ status: 2
 pattern: 'Quote: [block_content:field_author]'
 escape: false
 preserve_titles: false
+save: true
+chunk: 50
 dependencies:
   config:
     - block_content.type.quote
-save: 1
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/auto_entitylabel.settings.block_content.slider.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.slider.yml
@@ -4,8 +4,9 @@ status: 2
 pattern: 'Slider: [block_content:field_title]'
 escape: false
 preserve_titles: false
+save: false
+chunk: 50
 dependencies:
   config:
     - block_content.type.slider
-save: 0
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/auto_entitylabel.settings.block_content.text.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.text.yml
@@ -4,8 +4,9 @@ status: 1
 pattern: '[block_content:field_title]'
 escape: false
 preserve_titles: false
+save: false
+chunk: 50
 dependencies:
   config:
     - block_content.type.text
-save: 0
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/auto_entitylabel.settings.block_content.views.yml
+++ b/config/sync/auto_entitylabel.settings.block_content.views.yml
@@ -4,8 +4,9 @@ status: 2
 pattern: 'Views: [block_content:field_title]'
 escape: false
 preserve_titles: false
+save: false
+chunk: 50
 dependencies:
   config:
     - block_content.type.views
-save: 0
-chunk: '50'
+new_content_behavior: 1

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -1,15 +1,14 @@
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc
 module:
+  auto_entitylabel: -100
   action: 0
   address: 0
   address_map_link: 0
   admin_toolbar: 0
-  admin_toolbar_links_access_filter: 0
   admin_toolbar_tools: 0
   ajax_comments: 0
   allowed_formats: 0
-  auto_entitylabel: 0
   automated_cron: 0
   ban: 0
   better_exposed_filters: 0

--- a/web/modules/custom/nys_access_permissions/nys_access_permissions.info.yml
+++ b/web/modules/custom/nys_access_permissions/nys_access_permissions.info.yml
@@ -2,4 +2,4 @@ name: NYS Access Permissions
 type: module
 description: Custom Permissions for users and roles on the nysenate.gov site
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/nys_access_permissions/nys_access_permissions.module
+++ b/web/modules/custom/nys_access_permissions/nys_access_permissions.module
@@ -10,6 +10,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
 use Drupal\user\Entity\User;
+use Drupal\user\RoleInterface;
 
 /**
  * Implements hook_node_access().
@@ -29,7 +30,9 @@ function nys_access_permissions_node_access(NodeInterface $node, $operation, Acc
     if (!empty($node->uid->target_id) && $operation == 'update' && $account->hasPermission('edit same role')) {
       $author = User::load($node->uid->target_id);
       if (array_intersect($account->getRoles(), $author->getRoles())) {
-        $edit_same_roles = user_roles(TRUE, 'edit same role');
+        $edit_same_roles = Role::loadMultiple();
+        unset($edit_same_roles[RoleInterface::ANONYMOUS_ID]);
+        $edit_same_roles = array_filter($edit_same_roles, fn(RoleInterface $edit_same_roles) => $edit_same_roles->hasPermission('edit same role'));
         foreach ($author->getRoles() as $role) {
           if (in_array($role, $account->getRoles()) && in_array($role, array_keys($edit_same_roles))) {
             return AccessResult::allowed();

--- a/web/modules/custom/nys_access_permissions/nys_access_permissions.module
+++ b/web/modules/custom/nys_access_permissions/nys_access_permissions.module
@@ -9,6 +9,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
+use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 use Drupal\user\RoleInterface;
 

--- a/web/modules/custom/nys_accumulator/nys_accumulator.info.yml
+++ b/web/modules/custom/nys_accumulator/nys_accumulator.info.yml
@@ -1,7 +1,7 @@
 name: NYS Accumulator
 type: module
 description: Records interactive events for integration with Bluebird.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: NYS Senate
 
 dependencies:

--- a/web/modules/custom/nys_bill_notifications/nys_bill_notifications.info.yml
+++ b/web/modules/custom/nys_bill_notifications/nys_bill_notifications.info.yml
@@ -2,7 +2,7 @@ name: NYS Bill Notifications
 type: module
 description: Handles subscriptions to single bills and bill lineages
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - nys_subscriptions:nys_subscriptions
   - nys_sendgrid:nys_sendgrid

--- a/web/modules/custom/nys_bill_vote/nys_bill_vote.info.yml
+++ b/web/modules/custom/nys_bill_vote/nys_bill_vote.info.yml
@@ -2,7 +2,7 @@ name: NYS Bill Vote
 type: module
 description: Allows visitors to vote aye or nay on bills ((based on is_useful contrib module)
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - flag:flag
   - nys_bills:nys_bills

--- a/web/modules/custom/nys_bills/nys_bills.info.yml
+++ b/web/modules/custom/nys_bills/nys_bills.info.yml
@@ -2,7 +2,7 @@ name: NYS Bills
 type: module
 description: Custom bills functionality for New York Senate.
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - nys_senators:nys_senators

--- a/web/modules/custom/nys_blocks/nys_blocks.info.yml
+++ b/web/modules/custom/nys_blocks/nys_blocks.info.yml
@@ -1,7 +1,7 @@
 name: NYS Blocks
 type: module
 description: Defines custom blocks for NYS Senate.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: NYS Senate
 dependencies:
   - block

--- a/web/modules/custom/nys_calendar/nys_calendar.info.yml
+++ b/web/modules/custom/nys_calendar/nys_calendar.info.yml
@@ -2,4 +2,4 @@ name: NYS Calendar and Events, custom code
 type: module
 description: Custom code for event content type and calendar functionality
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/nys_comment/nys_comment.info.yml
+++ b/web/modules/custom/nys_comment/nys_comment.info.yml
@@ -2,6 +2,6 @@ name: NYS Comment
 type: module
 description: Custom module that extends to core comments module.
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:comment

--- a/web/modules/custom/nys_committees/nys_committees.info.yml
+++ b/web/modules/custom/nys_committees/nys_committees.info.yml
@@ -2,6 +2,6 @@ name: NYS Committees
 type: module
 description: Collection of helpers targeting the Committees taxonomy
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - nys_dashboard:nys_dashboard

--- a/web/modules/custom/nys_config/nys_config.info.yml
+++ b/web/modules/custom/nys_config/nys_config.info.yml
@@ -1,5 +1,5 @@
 name: NYS Config
 type: module
 description: NYS Config.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: NYSenate

--- a/web/modules/custom/nys_contrib_alters/nys_contrib_alters.info.yml
+++ b/web/modules/custom/nys_contrib_alters/nys_contrib_alters.info.yml
@@ -1,5 +1,5 @@
 name: NYS Senate Contrib Alters
 type: module
 description: Alterations to contrib modules.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: NYSenate

--- a/web/modules/custom/nys_dashboard/nys_dashboard.info.yml
+++ b/web/modules/custom/nys_dashboard/nys_dashboard.info.yml
@@ -2,4 +2,4 @@ name: NYS Dashboard
 type: module
 description: Custom module for routing dashboard pages.
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/nys_homepage_hero/nys_homepage_hero.info.yml
+++ b/web/modules/custom/nys_homepage_hero/nys_homepage_hero.info.yml
@@ -2,6 +2,6 @@ name: NYS Homepage Hero Refresh
 type: module
 description: Enables automatic refresh of the homepage for client browsers.
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - entityqueue:entityqueue

--- a/web/modules/custom/nys_issues/nys_issues.info.yml
+++ b/web/modules/custom/nys_issues/nys_issues.info.yml
@@ -2,6 +2,6 @@ name: NYS Issues
 type: module
 description: Collection of helpers targeting the Issues taxonomy
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - nys_dashboard:nys_dashboard

--- a/web/modules/custom/nys_issues/src/Controller/IssuesManagementController.php
+++ b/web/modules/custom/nys_issues/src/Controller/IssuesManagementController.php
@@ -74,7 +74,7 @@ class IssuesManagementController extends ControllerBase {
 
     $link = Link::fromTextAndUrl($tid->getName(), $tid->toUrl())->toString();
 
-    $ret = $this->renderer->renderPlain($ret);
+    $ret = $this->renderer->renderInIsolation($ret);
 
     return new HtmlResponse($ret);
   }

--- a/web/modules/custom/nys_legislation_explorer/nys_legislation_explorer.info.yml
+++ b/web/modules/custom/nys_legislation_explorer/nys_legislation_explorer.info.yml
@@ -2,4 +2,4 @@ name: NYS Legislation Explorer
 type: module
 description: Module for pages for searching open leg API
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/nys_list_formatter/nys_list_formatter.info.yml
+++ b/web/modules/custom/nys_list_formatter/nys_list_formatter.info.yml
@@ -1,7 +1,7 @@
 name: 'NYS List formatter'
 type: module
 description: 'A field formatter for rendering values as HTML or comma-separated lists.'
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: Fields
 dependencies:
   - field

--- a/web/modules/custom/nys_messaging/nys_messaging.info.yml
+++ b/web/modules/custom/nys_messaging/nys_messaging.info.yml
@@ -2,6 +2,6 @@ name: NYS Messaging
 type: module
 description: Custom messaging module extending the private_messaging module functionality.
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - private_message

--- a/web/modules/custom/nys_metatags/nys_metatags.info.yml
+++ b/web/modules/custom/nys_metatags/nys_metatags.info.yml
@@ -2,6 +2,6 @@ name: NYS Metatags
 type: module
 description: Custom overrides for Metatags
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - metatag

--- a/web/modules/custom/nys_migrate/nys_migrate.info.yml
+++ b/web/modules/custom/nys_migrate/nys_migrate.info.yml
@@ -2,7 +2,7 @@ name: NYS Migrate
 type: module
 description: Custom migration module
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:migrate_drupal
   - migrate_plus:migrate_plus

--- a/web/modules/custom/nys_opendata/nys_opendata.info.yml
+++ b/web/modules/custom/nys_opendata/nys_opendata.info.yml
@@ -1,5 +1,5 @@
 name: 'NYS OpenData'
 description: "Handles presentation of Open Data nodes"
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module

--- a/web/modules/custom/nys_openleg/nys_openleg.info.yml
+++ b/web/modules/custom/nys_openleg/nys_openleg.info.yml
@@ -1,7 +1,7 @@
 name: 'NYS Openleg'
 description: "Enables browsing laws via NYS OpenLeg API"
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 configure: nys_openleg.config
 dependencies:

--- a/web/modules/custom/nys_openleg_api/nys_openleg_api.info.yml
+++ b/web/modules/custom/nys_openleg_api/nys_openleg_api.info.yml
@@ -1,6 +1,6 @@
 name: 'NYS OpenLeg API'
 description: "A service to facilitate calls to the NYS OpenLeg API"
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 configure: nys_openleg_api.config

--- a/web/modules/custom/nys_openleg_imports/nys_openleg_imports.info.yml
+++ b/web/modules/custom/nys_openleg_imports/nys_openleg_imports.info.yml
@@ -1,7 +1,7 @@
 name: 'NYS Openleg Imports'
 description: "A content import service for OpenLeg"
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 dependencies:
   - drupal:node

--- a/web/modules/custom/nys_petitions/nys_petitions.info.yml
+++ b/web/modules/custom/nys_petitions/nys_petitions.info.yml
@@ -2,6 +2,6 @@ name: NYS Petitions
 type: module
 description: Collection of helpers targeting Petitions
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - nys_dashboard:nys_dashboard

--- a/web/modules/custom/nys_petitions/src/Controller/PetitionsManagementController.php
+++ b/web/modules/custom/nys_petitions/src/Controller/PetitionsManagementController.php
@@ -100,7 +100,7 @@ class PetitionsManagementController extends ControllerBase {
     else {
       $ret = ['#markup' => 'Could not find any signatures'];
     }
-    $ret = $this->renderer->renderPlain($ret);
+    $ret = $this->renderer->renderInIsolation($ret);
 
     return new HtmlResponse($ret);
   }

--- a/web/modules/custom/nys_questionnaires/nys_questionnaires.info.yml
+++ b/web/modules/custom/nys_questionnaires/nys_questionnaires.info.yml
@@ -2,7 +2,7 @@ name: NYS Questionnaires
 type: module
 description: Custom work for Questionnaires
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - user
   - taxonomy

--- a/web/modules/custom/nys_questionnaires/src/Controller/QuestionnairesManagementController.php
+++ b/web/modules/custom/nys_questionnaires/src/Controller/QuestionnairesManagementController.php
@@ -100,7 +100,7 @@ class QuestionnairesManagementController extends ControllerBase {
     else {
       $ret = ['#markup' => 'Could not find any submissions'];
     }
-    $ret = $this->renderer->renderPlain($ret);
+    $ret = $this->renderer->renderInIsolation($ret);
 
     return new HtmlResponse($ret);
   }

--- a/web/modules/custom/nys_reading/nys_reading.info.yml
+++ b/web/modules/custom/nys_reading/nys_reading.info.yml
@@ -2,6 +2,6 @@ name: NYS Reading
 type: module
 description: Custom overrides for Summer Reading Form
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - nys_sage

--- a/web/modules/custom/nys_registration/nys_registration.info.yml
+++ b/web/modules/custom/nys_registration/nys_registration.info.yml
@@ -2,7 +2,7 @@ name: NYS Registration
 type: module
 description: Handles custom behaviors related to registering new users and account logins
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - nys_sage
   - path_alias

--- a/web/modules/custom/nys_sage/nys_sage.info.yml
+++ b/web/modules/custom/nys_sage/nys_sage.info.yml
@@ -1,6 +1,6 @@
 name: 'NYS Sage'
 description: "Provides a client to connect to the NYS SAGE service."
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 configure: nys_sage.config

--- a/web/modules/custom/nys_school_forms/nys_school_forms.info.yml
+++ b/web/modules/custom/nys_school_forms/nys_school_forms.info.yml
@@ -2,6 +2,6 @@ name: NYS Comment
 type: module
 description: Custom module to process school form functionality.
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:comment

--- a/web/modules/custom/nys_school_forms/src/Form/SchoolFormShowStudentForm.php
+++ b/web/modules/custom/nys_school_forms/src/Form/SchoolFormShowStudentForm.php
@@ -4,6 +4,7 @@ namespace Drupal\nys_school_forms\Form;
 
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystem;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\ConfirmFormBase;
@@ -213,7 +214,7 @@ class SchoolFormShowStudentForm extends ConfirmFormBase {
               $directory = 'public://' . 'webform' . '/' . $webform->id() . '/' . $sid . '/';
             }
             $file_uri = $file->getFileUri();
-            $file_exists_error = $this->fileSystem->getDestinationFilename($file_uri, FileSystemInterface::EXISTS_ERROR);
+            $file_exists_error = $this->fileSystem->getDestinationFilename($file_uri, FileExists::Error);
 
             if (!$file_exists_error) {
               $this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY);

--- a/web/modules/custom/nys_school_importer/nys_school_importer.info.yml
+++ b/web/modules/custom/nys_school_importer/nys_school_importer.info.yml
@@ -2,4 +2,4 @@ name: NYS School Importer
 type: module
 description: CSV School Importer Module
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/nys_school_importer/src/Form/NysedPageForm.php
+++ b/web/modules/custom/nys_school_importer/src/Form/NysedPageForm.php
@@ -9,6 +9,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Messenger\Messenger;
 use Drupal\Core\State\State;
+use Drupal\Core\StringTranslation\ByteSizeMarkup;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\nys_school_importer\ImporterHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -123,7 +124,7 @@ class NysedPageForm extends FormBase {
       'csvfile' => [
         '#title' => $this->t('CSV File'),
         '#type'  => 'file',
-        '#description' => ($max_size = ini_get('upload_max_filesize')) ? $this->t('Due to server restrictions, the <strong>maximum upload file size is %max_size</strong>. Files that exceed this size will be disregarded.', ['%max_size' => format_size($max_size)]) : '',
+        '#description' => ($max_size = ini_get('upload_max_filesize')) ? $this->t('Due to server restrictions, the <strong>maximum upload file size is %max_size</strong>. Files that exceed this size will be disregarded.', ['%max_size' => ByteSizeMarkup::create($max_size)]) : '',
       ],
       'submit' => [
         '#type' => 'submit',

--- a/web/modules/custom/nys_school_importer/src/Form/SurveyPageForm.php
+++ b/web/modules/custom/nys_school_importer/src/Form/SurveyPageForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Messenger\Messenger;
 use Drupal\Core\State\State;
+use Drupal\Core\StringTranslation\ByteSizeMarkup;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\nys_school_importer\ImporterHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -103,7 +104,7 @@ class SurveyPageForm extends FormBase {
       'csvfile' => [
         '#title' => $this->t('CSV File'),
         '#type'  => 'file',
-        '#description' => ($max_size = ini_get('upload_max_filesize')) ? $this->t('Due to server restrictions, the <strong>maximum upload file size is %max_size</strong>. Files that exceed this size will be disregarded.', ['%max_size' => format_size($max_size)]) : '',
+        '#description' => ($max_size = ini_get('upload_max_filesize')) ? $this->t('Due to server restrictions, the <strong>maximum upload file size is %max_size</strong>. Files that exceed this size will be disregarded.', ['%max_size' => ByteSizeMarkup::create($max_size)]) : '',
       ],
       'submit' => [
         '#type' => 'submit',

--- a/web/modules/custom/nys_search/nys_search.info.yml
+++ b/web/modules/custom/nys_search/nys_search.info.yml
@@ -2,4 +2,4 @@ name: NYS Search
 type: module
 description: Custom code for search functionality
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/nys_senators/nys_senators.info.yml
+++ b/web/modules/custom/nys_senators/nys_senators.info.yml
@@ -2,7 +2,7 @@ name: NYS Senators
 type: module
 description: Custom work for Senators and their Microsites
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - user
   - block

--- a/web/modules/custom/nys_sendgrid/nys_sendgrid.info.yml
+++ b/web/modules/custom/nys_sendgrid/nys_sendgrid.info.yml
@@ -1,7 +1,7 @@
 name: 'NYS Sendgrid'
 description: "Provides a Mailsystem plugin leveraging Sendgrid's API.  Does not provide any SMTP facilities."
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 configure: nys_sendgrid.config
 dependencies:

--- a/web/modules/custom/nys_slack/nys_slack.info.yml
+++ b/web/modules/custom/nys_slack/nys_slack.info.yml
@@ -1,6 +1,6 @@
 name: 'NYS Slack'
 description: "Provides a Drupal service to call a Slack application."
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 configure: nys_slack.config

--- a/web/modules/custom/nys_subscriptions/nys_subscriptions.info.yml
+++ b/web/modules/custom/nys_subscriptions/nys_subscriptions.info.yml
@@ -2,5 +2,5 @@ name: NYS Subscriptions
 type: module
 description: 'Provides a subscription entity.'
 package: NYSenate
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 configure: entity.subscription.settings

--- a/web/modules/custom/nys_sunset_policy/nys_sunset_policy.info.yml
+++ b/web/modules/custom/nys_sunset_policy/nys_sunset_policy.info.yml
@@ -2,6 +2,6 @@ name: NYS Sunset Policy
 type: module
 description: NYS Sunset Policy on expiring/expired questionnaires and petitions.
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:queue_ui

--- a/web/modules/custom/nys_users/nys_users.info.yml
+++ b/web/modules/custom/nys_users/nys_users.info.yml
@@ -2,6 +2,6 @@ name: NYS Users
 type: module
 description: Custom work for User logic within NY Senate
 package: Custom
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:user

--- a/web/profiles/custom/nysenate/modules/rain_core/rain_core.info.yml
+++ b/web/profiles/custom/nysenate/modules/rain_core/rain_core.info.yml
@@ -1,7 +1,7 @@
 name: Rain Core
 type: module
 description: "The core functionality provided for Rain-based installation profiles."
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: Rain
 dependencies:
   - admin_toolbar

--- a/web/profiles/custom/nysenate/modules/rain_media_bundle/rain_media_bundle.info.yml
+++ b/web/profiles/custom/nysenate/modules/rain_media_bundle/rain_media_bundle.info.yml
@@ -2,7 +2,7 @@ name: Rain Media
 type: module
 description: 'Provides media features and common bundles.'
 package: Rain
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - media
   - media_library

--- a/web/profiles/custom/nysenate/nysenate.info.yml
+++ b/web/profiles/custom/nysenate/nysenate.info.yml
@@ -1,7 +1,7 @@
 name: nysenate Profile
 type: profile
 description: 'Rename this profile to the appropriate client or project name.'
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 
 # Optional: Declare your installation profile as a distribution
 # This will make the installer auto-select this installation profile.

--- a/web/themes/custom/nysenate_theme/nysenate_theme.info.yml
+++ b/web/themes/custom/nysenate_theme/nysenate_theme.info.yml
@@ -13,7 +13,7 @@ name: NY STATE SENATE
 type: theme
 description: NY Senate theme built from the Rain base theme.
 package: Other
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 # Classy vs. Stable as a base theme: https://www.lullabot.com/articles/a-tale-of-two-base-themes-in-drupal-8-core
 base theme: rain_theme
 

--- a/web/themes/custom/rain_theme/rain_theme.info.yml
+++ b/web/themes/custom/rain_theme/rain_theme.info.yml
@@ -13,7 +13,7 @@ name: Rain Theme
 type: theme
 description: Drupal 8/9 theme for Rain distribution.
 package: Other
-core_version_requirement: '^9 || ^10'
+core_version_requirement: ^10 || ^11
 # Classy vs. Stable as a base theme: https://www.lullabot.com/articles/a-tale-of-two-base-themes-in-drupal-8-core
 base theme: classy
 


### PR DESCRIPTION
drupal/core (10.3.1 => 10.3.2):
patch removed/fixed: "3456738 - breaks log in": "https://www.drupal.org/files/issues/2024-06-25/3456738-9.patch"

drupal/admin_toolbar (3.4.2 => 3.5.0)
drupal/allowed_formats (3.0.0 => 3.0.1):
drupal/auto_entitylabel (3.2.0 => 3.3.0)
drupal/block_field (1.0.0-rc4 => 1.0.0-rc5)
drupal/devel (5.2.1 => 5.3.1)
drupal/email_registration (2.0.0-rc5 => 2.0.0-rc7) -- fixes "3456461 - Login fails with Drupal 10.3": "https://git.drupalcode.org/project/email_registration/-/merge_requests/43.patch"
drupal/entity_print (2.14.0 => 2.15.0)
drupal/entity_reference_revisions (1.11.0 => 1.12.0)
drupal/facets (2.0.7 => 2.0.8) :: https://www.drupal.org/project/facets/releases/2.0.8
drupal/fullcalendar_view (5.1.14 => 5.2.1)
drupal/geocoder (4.24.0 => 4.25.0)
drupal/google_tag (2.0.5 => 2.0.6)
drupal/inline_entity_form (3.0.0-rc19 => 3.0.0-rc20) -- updated patch/3099844
drupal/login_history (2.0.0-alpha3 => 2.0.0)
drupal/mailsystem (4.4.0 => 4.5.0)
drupal/metatag (2.0.0 => 2.0.2)
drupal/paragraphs (1.17.0 => 1.18.0):
drupal/password_policy (4.0.1 => 4.0.3)
drupal/pathauto (1.12.0 => 1.13.0)
drupal/recaptcha (3.3.0 => 3.4.0)
drupal/redirect (1.9.0 => 1.10.0)
drupal/search_api_solr (4.3.4 => 4.3.5) : lots going on in this update: https://www.drupal.org/project/search_api_solr/releases/4.3.5
drupal/token (1.14.0 => 1.15.0)
drupal/upgrade_status (4.3.4 => 4.3.5)
drupal/viewsreference (2.0.0-beta8 => 2.0.0-beta9)
drupal/webform_views (5.2.0 => 5.4.0)

**database updates:**

Module Update ID Type Description

admin_toolbar 8003 hook_update_n 8003 - Uninstall Admin Toolbar Links Access Filter for Drupal 10.3+. @see
https://www.drupal.org/project/admin_toolbar/issues/3463291

auto_entitylabel 8202 hook_update_n 8202 - Sets the new "New content behavior" config option to all existing configurations using "Create label after
first save" as the initial value, which preserves the old logic, that content is saved twice, (which may interfere
with other modules, but all tokens are supported). NOTE, if you desire to switch to the new logic, which creates the
label before saving the content (doesn't interfere with other modules, but not all tokens are supported), set the
"New content behavior" to "Create label before first save" in your "automatic label" settings.

auto_entitylabel 8301 hook_update_n 8301 - Lower module weight so to run before other modules.

honeypot 8103 hook_update_n 8103 - Adds an index on the 'hostname' column for the {honeypot_user} table.

honeypot 8104 hook_update_n 8104 - Flushes the Tour module cache in order to reload Honeypot tour tips.

login_history 8004 hook_update_n 8004 - Deletes records of deleted user from login_history.

**ALSO:**
removed deprecated modules:

- tour
- actions UI
- transliteration

Updated .info.yml files for nys custom modules/themes and fixed all Upgrade Status issues.