### PR TITLE
NYS 168: Restrict MCP block content edit access to blocks linked to their managed senators

### DIFF
--- a/config/sync/user.role.microsite_content_producer.yml
+++ b/config/sync/user.role.microsite_content_producer.yml
@@ -16,8 +16,6 @@ dependencies:
     - node.type.video
     - node.type.webform
   module:
-    - block
-    - block_content
     - captcha
     - contact
     - content_moderation
@@ -41,7 +39,6 @@ weight: 6
 is_admin: null
 permissions:
   - 'access administration pages'
-  - 'access block library'
   - 'access content'
   - 'access content overview'
   - 'access help pages'
@@ -50,9 +47,6 @@ permissions:
   - 'access toolbar'
   - 'access user contact forms'
   - 'access webform overview'
-  - 'administer block content'
-  - 'administer block types'
-  - 'administer blocks'
   - 'create article content'
   - 'create event content'
   - 'create field_featured'

--- a/web/modules/custom/nys_senators/nys_senators.module
+++ b/web/modules/custom/nys_senators/nys_senators.module
@@ -271,6 +271,15 @@ function nys_senators_entity_access(EntityInterface $entity, $operation, Account
 }
 
 /**
+ * Implements hook_entity_type_build().
+ */
+function nys_senators_entity_type_build(array &$entity_types) {
+  if (isset($entity_types['block_content'])) {
+    $entity_types['block_content']->setHandlerClass('access', '\Drupal\nys_senators\Access\McpBlockContentAccessControlHandler');
+  }
+}
+
+/**
  * Implements hook_entity_presave().
  */
 function nys_senators_user_presave(UserInterface $user) {

--- a/web/modules/custom/nys_senators/src/Access/McpBlockContentAccessControlHandler.php
+++ b/web/modules/custom/nys_senators/src/Access/McpBlockContentAccessControlHandler.php
@@ -62,16 +62,23 @@ class McpBlockContentAccessControlHandler extends BlockContentAccessControlHandl
     $current_user = UsersHelper::resolveUser();
     if (UsersHelper::isMcp($current_user)) {
       $managed_senator_tids = UsersHelper::getManagedSenators($current_user);
-      $is_block_linked_to_managed_senator = $this->entityTypeManager
-        ->getStorage('node')
-        ->getQuery()
-        ->accessCheck(FALSE)
-        ->condition('field_block', $entity->id(), 'CONTAINS')
-        ->condition('field_senator_multiref', $managed_senator_tids, 'IN')
-        ->count()
-        ->execute();
-      if ($is_block_linked_to_managed_senator) {
-        return AccessResult::allowed();
+      try {
+        $node_storage = $this->entityTypeManager
+          ->getStorage('node');
+      }
+      catch (\Exception) {
+      }
+      if (isset($node_storage)) {
+        $is_block_linked_to_managed_senator = $node_storage
+          ->getQuery()
+          ->accessCheck(FALSE)
+          ->condition('field_block', $entity->id(), 'CONTAINS')
+          ->condition('field_senator_multiref', $managed_senator_tids, 'IN')
+          ->count()
+          ->execute();
+        if ($is_block_linked_to_managed_senator) {
+          return AccessResult::allowed();
+        }
       }
     }
 

--- a/web/modules/custom/nys_senators/src/Access/McpBlockContentAccessControlHandler.php
+++ b/web/modules/custom/nys_senators/src/Access/McpBlockContentAccessControlHandler.php
@@ -62,7 +62,9 @@ class McpBlockContentAccessControlHandler extends BlockContentAccessControlHandl
     $current_user = UsersHelper::resolveUser();
     if (UsersHelper::isMcp($current_user)) {
       $managed_senator_tids = UsersHelper::getManagedSenators($current_user);
-      $is_block_linked_to_managed_senator = \Drupal::entityTypeManager()->getStorage('node')->getQuery()
+      $is_block_linked_to_managed_senator = $this->entityTypeManager
+        ->getStorage('node')
+        ->getQuery()
         ->accessCheck(FALSE)
         ->condition('field_block', $entity->id(), 'CONTAINS')
         ->condition('field_senator_multiref', $managed_senator_tids, 'IN')

--- a/web/modules/custom/nys_senators/src/Access/McpBlockContentAccessControlHandler.php
+++ b/web/modules/custom/nys_senators/src/Access/McpBlockContentAccessControlHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\nys_senators\Access;
+
+use Drupal\block_content\BlockContentAccessControlHandler;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\nys_users\UsersHelper;
+
+/**
+ * Custom content block access control handler for MCPs.
+ */
+class McpBlockContentAccessControlHandler extends BlockContentAccessControlHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    $current_user = UsersHelper::resolveUser();
+    if (UsersHelper::isMcp($current_user)) {
+      return AccessResult::allowed();
+    }
+
+    return parent::checkAccess($entity, $operation, $account);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
+    $current_user = UsersHelper::resolveUser();
+    if (UsersHelper::isMcp($current_user)) {
+      return AccessResult::allowed();
+    }
+
+    return parent::checkCreateAccess($account, $context, $entity_bundle);
+  }
+
+}

--- a/web/modules/custom/nys_senators/src/Access/McpBlockContentAccessControlHandler.php
+++ b/web/modules/custom/nys_senators/src/Access/McpBlockContentAccessControlHandler.php
@@ -17,11 +17,22 @@ class McpBlockContentAccessControlHandler extends BlockContentAccessControlHandl
    * {@inheritdoc}
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    // If user is an MCP, grant access to content blocks tied to their senator.
     $current_user = UsersHelper::resolveUser();
     if (UsersHelper::isMcp($current_user)) {
-      return AccessResult::allowed();
+      $managed_senator_tids = UsersHelper::getManagedSenators($current_user);
+      $is_block_linked_to_managed_senator = \Drupal::entityTypeManager()->getStorage('node')->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('field_block', $entity->id(), 'CONTAINS')
+        ->condition('field_senator_multiref', $managed_senator_tids, 'IN')
+        ->count()
+        ->execute();
+      if ($is_block_linked_to_managed_senator) {
+        return AccessResult::allowed();
+      }
     }
 
+    // Otherwise, fall back on core access rules.
     return parent::checkAccess($entity, $operation, $account);
   }
 
@@ -29,11 +40,13 @@ class McpBlockContentAccessControlHandler extends BlockContentAccessControlHandl
    * {@inheritdoc}
    */
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
+    // If user is an MCP, grant access to creating new content blocks.
     $current_user = UsersHelper::resolveUser();
     if (UsersHelper::isMcp($current_user)) {
       return AccessResult::allowed();
     }
 
+    // Otherwise, fall back on core access rules.
     return parent::checkCreateAccess($account, $context, $entity_bundle);
   }
 


### PR DESCRIPTION
Note that the related hotfix in https://github.com/nysenate/NYSenate.gov-Website-D9/pull/226 revokes all MCP block content access. This is the long term fix.