### PR TITLE
Fixes watchdog errors related to nys theme 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ build
 .ddev/commands/host/
 .ddev/docker-compose.phpmyadmin-norouter.yaml
 .ddev/docker-compose.phpmyadmin.yaml
+# Temporary documentation files
+CLAUDE.md
+THEME_AUDIT.md

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ build
 # Temporary documentation files
 CLAUDE.md
 THEME_AUDIT.md
+
+# Ignore SQL dumps
+*.sql.gz

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,10 @@ build
 # Temporary documentation files
 CLAUDE.md
 THEME_AUDIT.md
+broken_oembed_nodes.csv
+inactive_senator_webforms.csv
+inactive_senator_webforms.txt
+report_inactive_senator_webforms.php
 
 # Ignore SQL dumps
 *.sql.gz

--- a/config/sync/block.block.nys_school_form_block.yml
+++ b/config/sync/block.block.nys_school_form_block.yml
@@ -11,7 +11,7 @@ dependencies:
 id: nys_school_form_block
 theme: nys
 region: content
-weight: -6
+weight: 19
 provider: null
 plugin: formblock_node
 settings:

--- a/config/sync/seckit.settings.yml
+++ b/config/sync/seckit.settings.yml
@@ -22,11 +22,11 @@ seckit_xss:
     upgrade-req: false
     policy-uri: ''
   x_xss:
+    select: 0
     seckit_x_xss_option_disable: Disabled
     seckit_x_xss_option_0: '0'
     seckit_x_xss_option_1: 1;
     seckit_x_xss_option_1_block: '1; mode=block'
-    select: 0
 seckit_csrf:
   origin: true
   origin_whitelist: ''

--- a/config/sync/views.view.questionnaires.yml
+++ b/config/sync/views.view.questionnaires.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.storage.node.webform
     - node.type.webform
     - taxonomy.vocabulary.senator
+    - user.role.administrator
   module:
     - better_exposed_filters
     - datetime
@@ -584,9 +585,10 @@ display:
                   collapsible_disable_automatic_open: false
                   is_secondary: false
       access:
-        type: perm
+        type: role
         options:
-          perm: 'access content'
+          role:
+            administrator: administrator
       cache:
         type: tag
         options: {  }
@@ -835,7 +837,7 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.permissions
+        - user.roles
       tags:
         - 'config:field.storage.node.field_date'
         - 'config:field.storage.node.field_senator_multiref'
@@ -1814,7 +1816,7 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.permissions
+        - user.roles
       tags:
         - 'config:field.storage.node.field_date'
         - 'config:field.storage.node.field_senator_multiref'
@@ -1963,7 +1965,7 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.permissions
+        - user.roles
       tags:
         - 'config:field.storage.node.field_date'
         - 'config:field.storage.node.field_senator_multiref'

--- a/config/sync/views.view.questionnaires.yml
+++ b/config/sync/views.view.questionnaires.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_date
+    - field.storage.node.field_senator_multiref
     - field.storage.node.webform
     - node.type.webform
     - taxonomy.vocabulary.senator
@@ -11,6 +12,7 @@ dependencies:
     - better_exposed_filters
     - datetime
     - node
+    - nys_views
     - taxonomy
     - user
     - webform
@@ -30,6 +32,70 @@ display:
     display_options:
       title: Questionnaires
       fields:
+        field_date:
+          id: field_date
+          table: node__field_date
+          field: field_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Publish Date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_default
+          settings:
+            timezone_override: ''
+            format_type: html_date
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         title:
           id: title
           table: node_field_data
@@ -86,6 +152,69 @@ display:
           settings:
             link_to_entity: true
           group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_senator_multiref:
+          id: field_senator_multiref
+          table: node__field_senator_multiref
+          field: field_senator_multiref
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Senator
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -160,15 +289,15 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_date:
-          id: field_date
-          table: node__field_date
-          field: field_date
+        webform_status:
+          id: webform_status
+          table: node__webform
+          field: webform_status
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: field
-          label: 'Publish Date'
+          plugin_id: standard
+          label: 'Webform Status'
           exclude: false
           alter:
             alter_text: false
@@ -209,21 +338,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: datetime_default
-          settings:
-            timezone_override: ''
-            format_type: short
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
         status:
           id: status
           table: node_field_data
@@ -724,6 +838,7 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.field_date'
+        - 'config:field.storage.node.field_senator_multiref'
         - 'config:field.storage.node.webform'
   page_1:
     id: page_1
@@ -731,7 +846,955 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      fields:
+        field_date:
+          id: field_date
+          table: node__field_date
+          field: field_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Publish Date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_default
+          settings:
+            timezone_override: ''
+            format_type: html_date
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: 'Questionnaire Title'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_senator_multiref:
+          id: field_senator_multiref
+          table: node__field_senator_multiref
+          field: field_senator_multiref
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Senator
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        webform_status:
+          id: webform_status
+          table: node__webform
+          field: webform_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          label: 'Node Status'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        webform_entity_status:
+          id: webform_entity_status
+          table: node__webform
+          field: webform_entity_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: webform_entity_status
+          label: 'Webform status'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        webform_archive_status:
+          id: webform_archive_status
+          table: node__webform
+          field: webform_archive_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: webform_archive_status
+          label: 'Archived Status'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+          label: Published
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: yes-no
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        webform:
+          id: webform
+          table: node__webform
+          field: webform
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Webform
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<a href="/admin/webform/manage/{{ webform__target_id }}/settings">Webform Settings</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: status
+          type: webform_entity_reference_link
+          settings:
+            label: 'Link to webform'
+            dialog: ''
+            attributes: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        edit_node:
+          id: edit_node
+          table: node
+          field: edit_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link_edit
+          label: 'Node Edit'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: edit
+          output_url_as_text: false
+          absolute: false
+        webform_1:
+          id: webform_1
+          table: node__webform
+          field: webform
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '{{ webform_1__target_id }}'
+            make_link: false
+            path: '/admin/webform/manage/webform_{{ webform_1__target_id }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: webform_entity_reference_url
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            webform: webform
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        field_senator_multiref_target_id:
+          id: field_senator_multiref_target_id
+          table: node__field_senator_multiref
+          field: field_senator_multiref_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_senator_multiref_target_id_op
+            label: Senator
+            description: ''
+            use_operator: false
+            operator: field_senator_multiref_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: senator
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              rest_user: '0'
+              web_administrator: '0'
+              frontpage_editor: '0'
+              senator: '0'
+              microsite_content_producer: '0'
+              legislative_correspondent: '0'
+              student_programs: '0'
+              constituent: '0'
+              expert_mcp: '0'
+              senate_services: '0'
+              student_contest_judge: '0'
+              experimental_content_producer: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: senator
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
+        field_active_senator_value:
+          id: field_active_senator_value
+          table: taxonomy_term__field_active_senator
+          field: field_active_senator_value
+          relationship: field_senator_multiref
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Active Senator'
+            description: ''
+            use_operator: false
+            operator: field_active_senator_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: active_senator
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              rest_user: '0'
+              web_administrator: '0'
+              frontpage_editor: '0'
+              senator: '0'
+              microsite_content_producer: '0'
+              legislative_correspondent: '0'
+              student_programs: '0'
+              constituent: '0'
+              expert_mcp: '0'
+              senate_services: '0'
+              student_contest_judge: '0'
+              experimental_content_producer: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Published status'
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              rest_user: '0'
+              web_administrator: '0'
+              frontpage_editor: '0'
+              senator: '0'
+              microsite_content_producer: '0'
+              legislative_correspondent: '0'
+              student_programs: '0'
+              constituent: '0'
+              expert_mcp: '0'
+              senate_services: '0'
+              student_contest_judge: '0'
+              experimental_content_producer: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        webform_status:
+          id: webform_status
+          table: node__webform
+          field: webform_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Node status'
+            description: ''
+            use_operator: false
+            operator: webform_status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: webform_status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              frontpage_editor: '0'
+              senator: '0'
+              microsite_content_producer: '0'
+              legislative_correspondent: '0'
+              student_programs: '0'
+              constituent: '0'
+              comment_moderator: '0'
+            placeholder: ''
+            autocomplete_filter: 0
+            autocomplete_min_chars: '0'
+            autocomplete_items: '10'
+            autocomplete_field: webform_status
+            autocomplete_raw_suggestion: 1
+            autocomplete_raw_dropdown: 1
+            autocomplete_dependent: 0
+            autocomplete_contextual: 0
+            autocomplete_autosubmit: 0
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        webform_entity_status:
+          id: webform_entity_status
+          table: node__webform
+          field: webform_entity_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: webform_entity_status
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Webform status'
+            description: ''
+            use_operator: false
+            operator: webform_entity_status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: webform_entity_status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              frontpage_editor: '0'
+              senator: '0'
+              microsite_content_producer: '0'
+              legislative_correspondent: '0'
+              student_programs: '0'
+              constituent: '0'
+              comment_moderator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        webform_archive_status:
+          id: webform_archive_status
+          table: node__webform
+          field: webform_archive_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: webform_archive_status
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Archived Status'
+            description: ''
+            use_operator: false
+            operator: webform_archive_status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: webform_archive_status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              frontpage_editor: '0'
+              senator: '0'
+              microsite_content_producer: '0'
+              legislative_correspondent: '0'
+              student_programs: '0'
+              constituent: '0'
+              comment_moderator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        fields: false
+        filters: false
+        filter_groups: false
+        header: false
       display_description: ''
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: false
+          content: '<br><br>NOTE: Node status will always override webform status. So if webform is open on node, but closed on webform, the form will show as open. If node status is blank, it is because it was not set on the node at all.'
+          tokenize: false
       display_extenders: {  }
       path: admin/content/questionnaires
       menu:
@@ -754,6 +1817,7 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.field_date'
+        - 'config:field.storage.node.field_senator_multiref'
         - 'config:field.storage.node.webform'
   senator_qs:
     id: senator_qs
@@ -902,4 +1966,5 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.field_date'
+        - 'config:field.storage.node.field_senator_multiref'
         - 'config:field.storage.node.webform'

--- a/web/modules/custom/nys_senators/src/Service/SenatorsJson.php
+++ b/web/modules/custom/nys_senators/src/Service/SenatorsJson.php
@@ -192,7 +192,7 @@ class SenatorsJson {
         "city" => $address->getLocality() ?? '',
         "province" => $admin_area,
         "postal_code" => $address->getPostalCode() ?? '',
-        "country" => $$country,
+        "country" => $country,
         "province_name" => $this->statesList()[$admin_area] ?? '',
         "country_name" => $country_name,
         "fax" => $office->field_fax->value ?? '',

--- a/web/modules/custom/nys_views/nys_views.module
+++ b/web/modules/custom/nys_views/nys_views.module
@@ -32,3 +32,54 @@ function nys_views_views_data(): array {
 
   return $data;
 }
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function nys_views_views_data_alter(array &$data): void {
+  // The webform module exposes webform_status as a filter/sort/argument but
+  // not as a displayable field. Add the missing field handler so it can be
+  // added as a column in Views. NULL means the node inherits the webform
+  // entity's own status rather than overriding it.
+  if (isset($data['node__webform']['webform_status'])) {
+    $data['node__webform']['webform_status']['field'] = [
+      'id' => 'standard',
+    ];
+    $data['node__webform']['webform_status']['filter']['id'] = 'webform_node_status';
+  }
+
+  // Expose webform archive status. Webforms are config entities so this is
+  // not in any DB table — a custom field plugin loads the entity per row.
+  if (isset($data['node__webform'])) {
+    $data['node__webform']['webform_archive_status'] = [
+      'group' => t('Content'),
+      'title' => t('Webform: Archived'),
+      'help' => t('Whether the webform entity is archived.'),
+      'field' => [
+        'id' => 'webform_archive_status',
+        'real field' => 'webform_target_id',
+      ],
+      'filter' => [
+        'id' => 'webform_archive_status',
+        'real field' => 'webform_target_id',
+      ],
+    ];
+
+    // Expose webform entity status (open/closed/scheduled). This reflects the
+    // webform's own setting, distinct from the node-level webform_status
+    // override. Webforms are config entities so a custom plugin loads per row.
+    $data['node__webform']['webform_entity_status'] = [
+      'group' => t('Content'),
+      'title' => t('Webform: Entity status'),
+      'help' => t("The webform entity's own status (open/closed/scheduled), ignoring any node-level override."),
+      'field' => [
+        'id' => 'webform_entity_status',
+        'real field' => 'webform_target_id',
+      ],
+      'filter' => [
+        'id' => 'webform_entity_status',
+        'real field' => 'webform_target_id',
+      ],
+    ];
+  }
+}

--- a/web/modules/custom/nys_views/src/Plugin/views/field/WebformArchiveStatus.php
+++ b/web/modules/custom/nys_views/src/Plugin/views/field/WebformArchiveStatus.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\nys_views\Plugin\views\field;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Field handler to display whether a referenced webform entity is archived.
+ *
+ * Webforms are config entities so archive status is not in any DB table;
+ * this plugin loads the entity per row to retrieve it.
+ *
+ * @ViewsField("webform_archive_status")
+ */
+class WebformArchiveStatus extends FieldPluginBase {
+
+  /**
+   * Constructs a WebformArchiveStatus field plugin.
+   */
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    mixed $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function clickSortable(): bool {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $webform_id = $this->getValue($values);
+    if (!$webform_id) {
+      return '';
+    }
+    $webform = $this->entityTypeManager->getStorage('webform')->load($webform_id);
+    if (!$webform) {
+      return '';
+    }
+    return $webform->isArchived() ? $this->t('Yes') : $this->t('No');
+  }
+
+}

--- a/web/modules/custom/nys_views/src/Plugin/views/field/WebformEntityStatus.php
+++ b/web/modules/custom/nys_views/src/Plugin/views/field/WebformEntityStatus.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\nys_views\Plugin\views\field;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Field handler to display the status of the referenced webform entity.
+ *
+ * Webforms are config entities so status is not in any DB table; this plugin
+ * loads the entity per row to retrieve the raw status property ('open',
+ * 'closed', or 'scheduled'). This reflects the webform's own setting, not
+ * any node-level override (see webform_status for that).
+ *
+ * @ViewsField("webform_entity_status")
+ */
+class WebformEntityStatus extends FieldPluginBase {
+
+  /**
+   * Constructs a WebformEntityStatus field plugin.
+   */
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    mixed $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function clickSortable(): bool {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $webform_id = $this->getValue($values);
+    if (!$webform_id) {
+      return '';
+    }
+    $webform = $this->entityTypeManager->getStorage('webform')->load($webform_id);
+    if (!$webform) {
+      return '';
+    }
+    // $webform->status is a protected property; toArray() exposes raw config.
+    $status = $webform->toArray()['status'] ?? '';
+    return match($status) {
+      'open' => $this->t('Open'),
+      'closed' => $this->t('Closed'),
+      'scheduled' => $this->t('Scheduled'),
+      default => $status,
+    };
+  }
+
+}

--- a/web/modules/custom/nys_views/src/Plugin/views/filter/WebformArchiveStatus.php
+++ b/web/modules/custom/nys_views/src/Plugin/views/filter/WebformArchiveStatus.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\nys_views\Plugin\views\filter;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filter by webform archive status.
+ *
+ * Webforms are config entities so archive status is not in any DB table.
+ * This filter resolves archived/non-archived webform IDs at query time and
+ * adds a WHERE IN clause on node__webform.webform_target_id.
+ *
+ * @ViewsFilter("webform_archive_status")
+ */
+class WebformArchiveStatus extends FilterPluginBase {
+
+  /**
+   * Constructs a WebformArchiveStatus filter plugin.
+   */
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    mixed $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary(): string {
+    $val = is_array($this->value) ? reset($this->value) : $this->value;
+    return match($val) {
+      '1' => (string) $this->t('Archived'),
+      '0' => (string) $this->t('Not archived'),
+      default => (string) $this->t('All'),
+    };
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function valueForm(&$form, FormStateInterface $form_state): void {
+    $val = is_array($this->value) ? reset($this->value) : ($this->value ?? 'All');
+    $form['value'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Archived'),
+      '#options' => [
+        'All' => $this->t('- Any -'),
+        '1' => $this->t('Yes'),
+        '0' => $this->t('No'),
+      ],
+      '#default_value' => $val,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query(): void {
+    // Views wraps exposed filter values in an array via acceptExposedInput().
+    $val = is_array($this->value) ? reset($this->value) : $this->value;
+    if ($val === NULL || $val === '' || $val === FALSE || $val === 'All') {
+      return;
+    }
+
+    $storage = $this->entityTypeManager->getStorage('webform');
+    $query = $storage->getQuery()->accessCheck(FALSE);
+
+    if ($val === '1') {
+      $query->condition('archive', TRUE);
+    }
+    else {
+      $query->condition('archive', FALSE);
+    }
+
+    $webform_ids = $query->execute();
+
+    $this->ensureMyTable();
+    $field = "$this->tableAlias.webform_target_id";
+
+    if (empty($webform_ids)) {
+      // No webforms match — add an always-false condition.
+      $this->query->addWhereExpression($this->options['group'], '1 = 0');
+      return;
+    }
+
+    $this->query->addWhere($this->options['group'], $field, array_values($webform_ids), 'IN');
+  }
+
+}

--- a/web/modules/custom/nys_views/src/Plugin/views/filter/WebformEntityStatus.php
+++ b/web/modules/custom/nys_views/src/Plugin/views/filter/WebformEntityStatus.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\nys_views\Plugin\views\filter;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filter by webform entity status (open/closed/scheduled).
+ *
+ * Webforms are config entities so status is not in any DB table. This filter
+ * resolves webform IDs matching the selected status at query time and adds a
+ * WHERE IN clause on node__webform.webform_target_id.
+ *
+ * This reflects the webform's own setting, not any node-level override
+ * (see webform_status for that).
+ *
+ * @ViewsFilter("webform_entity_status")
+ */
+class WebformEntityStatus extends FilterPluginBase {
+
+  /**
+   * Constructs a WebformEntityStatus filter plugin.
+   */
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    mixed $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary(): string {
+    $val = is_array($this->value) ? reset($this->value) : $this->value;
+    return match($val) {
+      'open' => (string) $this->t('Open'),
+      'closed' => (string) $this->t('Closed'),
+      'scheduled' => (string) $this->t('Scheduled'),
+      default => (string) $this->t('All'),
+    };
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function valueForm(&$form, FormStateInterface $form_state): void {
+    $val = is_array($this->value) ? reset($this->value) : ($this->value ?? 'All');
+    $form['value'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Webform entity status'),
+      '#options' => [
+        'All' => $this->t('- Any -'),
+        'open' => $this->t('Open'),
+        'closed' => $this->t('Closed'),
+        'scheduled' => $this->t('Scheduled'),
+      ],
+      '#default_value' => $val,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query(): void {
+    // Views wraps exposed filter values in an array via acceptExposedInput().
+    $val = is_array($this->value) ? reset($this->value) : $this->value;
+    if ($val === NULL || $val === '' || $val === FALSE || $val === 'All') {
+      return;
+    }
+
+    $storage = $this->entityTypeManager->getStorage('webform');
+    $query = $storage->getQuery()->accessCheck(FALSE);
+    $query->condition('status', $val);
+    $webform_ids = $query->execute();
+
+    $this->ensureMyTable();
+    $field = "$this->tableAlias.webform_target_id";
+
+    if (empty($webform_ids)) {
+      // No webforms match — add an always-false condition.
+      $this->query->addWhereExpression($this->options['group'], '1 = 0');
+      return;
+    }
+
+    $this->query->addWhere($this->options['group'], $field, array_values($webform_ids), 'IN');
+  }
+
+}

--- a/web/modules/custom/nys_views/src/Plugin/views/filter/WebformNodeStatus.php
+++ b/web/modules/custom/nys_views/src/Plugin/views/filter/WebformNodeStatus.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\nys_views\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+
+/**
+ * Filter by webform node-level status override.
+ *
+ * The node__webform.webform_status column stores 'open', 'closed',
+ * 'scheduled', or NULL (inherit from the webform entity). This filter
+ * provides a select dropdown instead of the default plain text field.
+ *
+ * @ViewsFilter("webform_node_status")
+ */
+class WebformNodeStatus extends FilterPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary(): string {
+    $val = is_array($this->value) ? reset($this->value) : $this->value;
+    return match($val) {
+      'open' => (string) $this->t('Open'),
+      'closed' => (string) $this->t('Closed'),
+      'scheduled' => (string) $this->t('Scheduled'),
+      default => (string) $this->t('All'),
+    };
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function valueForm(&$form, FormStateInterface $form_state): void {
+    $val = is_array($this->value) ? reset($this->value) : ($this->value ?? 'All');
+    $form['value'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Status'),
+      '#options' => [
+        'All' => $this->t('- Any -'),
+        'open' => $this->t('Open'),
+        'closed' => $this->t('Closed'),
+        'scheduled' => $this->t('Scheduled'),
+      ],
+      '#default_value' => $val,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query(): void {
+    // Views wraps exposed filter values in an array via acceptExposedInput().
+    $val = is_array($this->value) ? reset($this->value) : $this->value;
+    if ($val === NULL || $val === '' || $val === FALSE || $val === 'All') {
+      return;
+    }
+    $this->ensureMyTable();
+    $this->query->addWhere($this->options['group'], "$this->tableAlias.webform_status", $val, '=');
+  }
+
+}

--- a/web/themes/custom/nys/nys.info.yml
+++ b/web/themes/custom/nys/nys.info.yml
@@ -32,20 +32,7 @@ regions:
 libraries:
   - nys/global
 
-# This section is used by the contrib module, Component Libraries. It allows you
-# to reference .twig files in your sass/ directory by using the Twig namespace:
-# @rain_theme and @nysenate_theme. As we move to SDC components, we can begin
-# to remove these dependencies.
-# See https://www.drupal.org/project/components for more information.
-components:
-  namespaces:
-    rain_theme:
-      - src/patterns/global
-      - src/patterns/components
-      - src/patterns/pages
-      - src/templates
-    nysenate_theme:
-      - src/patterns/global
-      - src/patterns/components
-      - src/patterns/pages
-      - src/templates
+# NOTE: Twig namespaces (@rain_theme, @nysenate_theme) are inherited from the
+# parent theme (nysenate_theme). Do not re-declare them here, as the paths
+# would be resolved relative to this theme directory where they don't exist,
+# causing Components module to log warnings on every page request.

--- a/web/themes/custom/nysenate_theme/.gitignore
+++ b/web/themes/custom/nysenate_theme/.gitignore
@@ -26,3 +26,4 @@ dist/js/*
 patternlab
 dependencyGraph.json
 
+REFACTOR_STATUS.md

--- a/web/themes/custom/nysenate_theme/src/templates/content/node--event--upcoming-event.html.twig
+++ b/web/themes/custom/nysenate_theme/src/templates/content/node--event--upcoming-event.html.twig
@@ -98,7 +98,8 @@
 
   <div{{ content_attributes.addClass('node__content') }}>
     <article class="c-event-block c-event-block--list">
-      <div class="c-event-date"><span>{{ node.field_date_range.value|date('U')|format_date('day_only') }}</span> {{ node.field_date_range.value|date('U')|format_date('month_only') }}</div>
+      <div class="c-event-date"><span>{{ node.field_date_range.start_date|date('U')|format_date('day_only') }}</span>
+        {{ node.field_date_range.start_date|date('U')|format_date('month_only') }}</div>
       <div class="event-details">
         <a href="{{ url }}"><h3 class="c-event-name">{{ label }}</h3></a>
 


### PR DESCRIPTION
Removed the entire components section from nys/nys.info.yml (lines 40-51).

  The child theme inherits these namespaces from its parent (nysenate_theme), so re-declaring them is:
  1. Unnecessary
  2. Causing the path resolution errors