### PR TITLE
Adds additional php8.4 fixes to views_combine patch

### DIFF
--- a/patches/views_combine-php84-nullable.patch
+++ b/patches/views_combine-php84-nullable.patch
@@ -9,3 +9,25 @@
      parent::init($view, $display, $options);
      $this->options['exclude'] = 1;
    }
+--- a/src/Plugin/views/filter/Combine.php
++++ b/src/Plugin/views/filter/Combine.php
+@@ -24,7 +24,7 @@
+   /**
+    * {@inheritdoc}
+    */
+-  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
++  public function init(ViewExecutable $view, DisplayPluginBase $display, ?array &$options = NULL) {
+     parent::init($view, $display, $options);
+     $this->valueTitle = $this->t('Views');
+   }
+--- a/src/ViewsCombiner.php
++++ b/src/ViewsCombiner.php
+@@ -212,7 +212,7 @@
+    * @return \Drupal\views\ViewExecutable|null
+    *   Returns the built view executable.
+    */
+-  public function buildView(string $view_id, string $display_id, ViewExecutable $base_view, FieldPluginBase $field_handler = NULL) {
++  public function buildView(string $view_id, string $display_id, ViewExecutable $base_view, ?FieldPluginBase $field_handler = NULL) {
+     if ($view = $this->getView($view_id, $display_id)) {
+       $input = $base_view->exposed_raw_input;
+


### PR DESCRIPTION
 Drupal\views_combine\Plugin\views\filter\Combine::init(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used       
  instead in /var/www/html/web/modules/contrib/views_combine/src/Plugin/views/filter/Combine.php on line 27                                                                
                                                                                                                                                                           
  Deprecated: Drupal\views_combine\ViewsCombiner::buildView(): Implicitly marking parameter $field_handler as nullable is deprecated, the explicit nullable type must be   
  used instead in /var/www/html/web/modules/contrib/views_combine/src/ViewsCombiner.php on line 215 