### PR TITLE
Fix broken PDF upload on /admin/settings/nysenate

### DIFF
--- a/web/modules/custom/nys_config/src/Form/ConfigForm.php
+++ b/web/modules/custom/nys_config/src/Form/ConfigForm.php
@@ -44,7 +44,7 @@ class ConfigForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('nys_config.settings');
     $validators = [
-      'file_validate_extensions' => ['pdf'],
+      'FileExtension' => ['extensions' => 'pdf'],
     ];
 
     /*


### PR DESCRIPTION
file_validate_extensions is a legacy procedural validator name removed in the Drupal 10.2/11 file-validation refactor to Symfony Constraint plugins, causing a PluginNotFoundException on save whenever a content editor uploaded a PDF on this form. Updated to the current constraint syntax, matching core's own usage (e.g. ImportForm.php, ThemeSettingsForm.php): 'FileExtension' => ['extensions' => 'pdf'].